### PR TITLE
Cache creating getter on ORM

### DIFF
--- a/Sources/VergeCore/ValueContainerType.swift
+++ b/Sources/VergeCore/ValueContainerType.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol ValueContainerType {
+public protocol ValueContainerType: AnyObject {
   associatedtype Value
     
   func getter<Output>(

--- a/Tests/VergeORMTests/SelectorTests.swift
+++ b/Tests/VergeORMTests/SelectorTests.swift
@@ -219,4 +219,37 @@ class SelectorTests: XCTestCase {
     XCTAssertEqual(updatedCount, 2)
     
   }
+  
+  func testGetterCache() {
+    
+    let storage = Storage<RootState>(.init())
+    
+    let getter1 = storage.entityGetter(entityID: Author.ID("Hoo"))
+    let getter2 = storage.entityGetter(entityID: Author.ID("Hoo"))
+    
+    XCTAssert(getter1 === getter2)
+    
+  }
+  
+  func testPerformanceGetterCreationIncludesFirstTime() {
+    
+    let storage = Storage<RootState>(.init())
+    
+    measure {
+      let _ = storage.entityGetter(entityID: Author.ID("Hoo"))
+    }
+    
+  }
+  
+  func testPerformanceGetterCreationWithCache() {
+        
+    let storage = Storage<RootState>(.init())
+    
+    let _ = storage.entityGetter(entityID: Author.ID("Hoo"))
+    
+    measure {
+      let _ = storage.entityGetter(entityID: Author.ID("Hoo"))
+    }
+                
+  }
 }

--- a/Verge.xcodeproj/xcshareddata/xcbaselines/4B475BC4239ADE1C008A03E1.xcbaseline/69A9E129-26EC-4D5C-AB76-D2FDC545E69F.plist
+++ b/Verge.xcodeproj/xcshareddata/xcbaselines/4B475BC4239ADE1C008A03E1.xcbaseline/69A9E129-26EC-4D5C-AB76-D2FDC545E69F.plist
@@ -203,6 +203,39 @@
 				</dict>
 			</dict>
 		</dict>
+		<key>SelectorTests</key>
+		<dict>
+			<key>testPerformanceGetterCreationFirstTime()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.00035259</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testPerformanceGetterCreationIncludesFirstTime()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.00023943</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testPerformanceGetterCreationWithCache()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>6.98e-05</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Using cache to reduce the cost of creating a getter that points to same entity-id.