### PR TITLE
Add UpdatedMarker with FragmentState

### DIFF
--- a/Sources/VergeCore/FragmentState.swift
+++ b/Sources/VergeCore/FragmentState.swift
@@ -1,0 +1,40 @@
+//
+//  StateFragment.swift
+//  VergeCore
+//
+//  Created by muukii on 2020/01/13.
+//  Copyright © 2020 muukii. All rights reserved.
+//
+
+import Foundation
+
+@dynamicMemberLookup
+public struct Fragment<State> {
+  
+  private(set) public var counter: UpdatedMarker = .init()
+  
+  public init(_ state: State) {
+    self.state = state
+  }
+  
+  public var state: State {
+    didSet {
+      counter.markAsUpdated()
+    }
+  }
+  
+  public subscript <T>(dynamicMember keyPath: KeyPath<State, T>) -> T {
+    _read {
+      yield state[keyPath: keyPath]
+    }
+  }
+  
+  public subscript <T>(dynamicMember keyPath: WritableKeyPath<State, T>) -> T {
+    _read {
+      yield state[keyPath: keyPath]
+    }
+    _modify {
+      yield &state[keyPath: keyPath]
+    }
+  }
+}

--- a/Sources/VergeCore/Storage.swift
+++ b/Sources/VergeCore/Storage.swift
@@ -106,6 +106,10 @@ open class Storage<Value>: ReadonlyStorage<Value> {
   @discardableResult
   @inline(__always)
   public final func update<Result>(_ update: (inout Value) throws -> Result) rethrows -> Result {
+    let signpost = VergeSignpostTransaction("Storage.update")
+    defer {
+      signpost.end()
+    }
     do {
       let notifyValue: Value
       _lock.lock()

--- a/Sources/VergeCore/UpdatedMarker.swift
+++ b/Sources/VergeCore/UpdatedMarker.swift
@@ -1,0 +1,26 @@
+//
+//  Counter.swift
+//  VergeCore
+//
+//  Created by muukii on 2020/01/13.
+//  Copyright © 2020 muukii. All rights reserved.
+//
+
+import Foundation
+
+/// A container manages raw value to describe mark as updated.
+public struct UpdatedMarker: Hashable {
+  
+  private(set) public var rawValue: UInt64 = 0
+  
+  public init() {}
+  
+  public mutating func markAsUpdated() {
+    guard rawValue < UInt64.max else {
+      rawValue &= 0
+      return
+    }
+    rawValue &+= 1
+  }
+  
+}

--- a/Sources/VergeORM/Database.swift.orig
+++ b/Sources/VergeORM/Database.swift.orig
@@ -90,8 +90,9 @@ extension DatabaseType {
 
 public struct DatabaseStorage<Schema: EntitySchemaType, Indexes: IndexesType> {
   
-  private(set) public var entityUpdatedMarker = UpdatedMarker()
-  private(set) public var indexUpdatedMarker = UpdatedMarker()
+<<<<<<< Updated upstream
+  private(set) public var entityUpdatedAt: Date = .init()
+  private(set) public var indexUpdatedAt: Date = .init()
   internal(set) public var lastUpdatesResult: DatabaseEntityUpdatesResult<Schema>?
   
   var entityBackingStorage: EntityTablesStorage<Schema> = .init()
@@ -99,8 +100,23 @@ public struct DatabaseStorage<Schema: EntitySchemaType, Indexes: IndexesType> {
   var indexesStorage: IndexesStorage<Schema, Indexes> = .init()
   
   mutating func markUpdated() {
-    entityUpdatedMarker.markAsUpdated()
-    indexUpdatedMarker.markAsUpdated()
+    entityUpdatedAt = .init()
+    indexUpdatedAt = .init()
+=======
+  private(set) public var entityUpdatedAt = Counter()
+  private(set) public var indexUpdatedAt = Counter()
+  
+  var entityBackingStorage: EntityTablesStorage<Schema> = .init() {
+    didSet {
+      entityUpdatedAt.increment()
+    }
+  }
+  
+  var indexesStorage: IndexesStorage<Schema, Indexes> = .init() {
+    didSet {
+      indexUpdatedAt.increment()
+    }
+>>>>>>> Stashed changes
   }
   
   public init() {

--- a/Sources/VergeORM/EntityTablesStorage.swift
+++ b/Sources/VergeORM/EntityTablesStorage.swift
@@ -34,20 +34,20 @@ protocol EntityTableType {
 struct EntityRawTable: Equatable {
   
   static func == (lhs: EntityRawTable, rhs: EntityRawTable) -> Bool {
-    guard lhs.updatedAt == rhs.updatedAt else { return false }
+    guard lhs.updatedMarker == rhs.updatedMarker else { return false }
     guard lhs.entities == rhs.entities else { return false }
     return true
   }
   
   typealias RawTable = [AnyHashable : AnyEntity]
   
-  var updatedAt: Date = .init()
+  private(set) var updatedMarker = UpdatedMarker()
 
   private(set) var entities: RawTable = [:]
   
   mutating func updateEntity<Result>(_ update: (inout RawTable) throws -> Result) rethrows -> Result {    
     let r = try update(&entities)
-    updatedAt = .init()
+    updatedMarker.markAsUpdated()
     return r
   }
     
@@ -67,8 +67,8 @@ public struct EntityTable<Schema: EntitySchemaType, Entity: EntityType>: EntityT
   
   let entityName: EntityName = Entity.entityName
   
-  public var updatedAt: Date {
-    _read { yield rawTable.updatedAt }
+  public var updatedMarker: UpdatedMarker {
+    _read { yield rawTable.updatedMarker }
   }
     
   /// The number of entities in table

--- a/Sources/VergeORM/Storage+Getter.swift
+++ b/Sources/VergeORM/Storage+Getter.swift
@@ -53,9 +53,9 @@ extension EqualityComputer where Input : DatabaseType {
   
   public static func databaseEqual() -> EqualityComputer<Input> {
     .init(
-      selector: { input -> (Date, Date) in
+      selector: { input -> (UpdatedMarker, UpdatedMarker) in
         let v = input
-        return (v._backingStorage.entityUpdatedAt, v._backingStorage.indexUpdatedAt)
+        return (v._backingStorage.entityUpdatedMarker, v._backingStorage.indexUpdatedMarker)
     },
       equals: { (old, new) -> Bool in
         old == new
@@ -64,8 +64,8 @@ extension EqualityComputer where Input : DatabaseType {
   
   public static func tableEqual<E: EntityType>(_ entityType: E.Type) -> EqualityComputer<Input> {
     let checkTableUpdated = EqualityComputer<Input>.init(
-      selector: { input -> Date in
-        return input._backingStorage.entityBackingStorage.table(E.self).updatedAt
+      selector: { input -> UpdatedMarker in
+        return input._backingStorage.entityBackingStorage.table(E.self).updatedMarker
     },
       equals: { (old, new) -> Bool in
         old == new
@@ -144,18 +144,9 @@ extension ValueContainerType where Value : DatabaseEmbedding {
   ) -> GetterSource<Value, Output> {
     
     let path = Value.getterToDatabase
-    
-    let checkDatabaseUpdated = EqualityComputer<Value.Database>.init(
-      selector: { input -> (Date, Date) in
-        let v = input
-        return (v._backingStorage.entityUpdatedAt, v._backingStorage.indexUpdatedAt)
-    },
-      equals: { (old, new) -> Bool in
-        old == new
-    })
-    
+           
     let computer = EqualityComputer.init(or: [
-      checkDatabaseUpdated,
+      .databaseEqual(),
       additionalEqualityComputer
       ].compactMap { $0 })
     

--- a/Sources/VergeRx/ORM/EntityGetter.swift
+++ b/Sources/VergeRx/ORM/EntityGetter.swift
@@ -63,18 +63,9 @@ extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbed
   ) -> RxGetterSource<Base.Value, Output> {
     
     let path = Base.Value.getterToDatabase
-    
-    let checkDatabaseUpdated = EqualityComputer<Base.Value.Database>.init(
-      selector: { input -> (Date, Date) in
-        let v = input
-        return (v._backingStorage.entityUpdatedAt, v._backingStorage.indexUpdatedAt)
-    },
-      equals: { (old, new) -> Bool in
-        old == new
-    })
-    
+      
     let computer = EqualityComputer.init(or: [
-      checkDatabaseUpdated,
+      .databaseEqual(),
       additionalEqualityComputer
       ].compactMap { $0 })
     

--- a/Sources/VergeStore/VergeStore.swift
+++ b/Sources/VergeStore/VergeStore.swift
@@ -126,11 +126,17 @@ open class StoreBase<State, Activity>: CustomReflectable, VergeStoreType {
     
     let startedTime = CFAbsoluteTimeGetCurrent()
     var currentState: State!
+    
+    let signpost = VergeSignpostTransaction("Store.commit")
+    
     let returnValue = _backingStorage.update { (state) -> Mutation.Result in
       let r = mutation.mutate(state: &state)
       currentState = state
       return r
     }
+    
+    signpost.end()
+    
     let elapsed = CFAbsoluteTimeGetCurrent() - startedTime
     
     logger?.didCommit(store: self, state: currentState!, mutation: mutation, context: context, time: elapsed)

--- a/Tests/VergeCoreTests/CounterTests.swift
+++ b/Tests/VergeCoreTests/CounterTests.swift
@@ -1,0 +1,53 @@
+//
+//  DateTests.swift
+//  VergeCore
+//
+//  Created by muukii on 2020/01/13.
+//  Copyright © 2020 muukii. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+
+import VergeCore
+
+final class CounterTests: XCTestCase {
+    
+  func testCounter() {
+    
+    var counter = UpdatedMarker()
+    
+    for _ in 0..<100 {
+      
+      counter.markAsUpdated()
+    }
+    
+    XCTAssertEqual(counter.rawValue, 100)
+  }
+  
+  func testCounterPerformance() {
+    var counter = UpdatedMarker()
+    if #available(iOS 13.0, *) {
+      measure(metrics: [XCTCPUMetric()]) {
+        counter.markAsUpdated()
+      }
+    } else {
+      // Fallback on earlier versions
+    }
+  }
+  
+  func testGenDatePerformance() {
+    
+    measure {
+      _ = Date()
+    }
+  }
+  
+  func testGenCFDatePerformance() {
+    
+    measure {
+      _ = CFAbsoluteTimeGetCurrent()
+    }
+  }
+}

--- a/Verge.xcodeproj/project.pbxproj
+++ b/Verge.xcodeproj/project.pbxproj
@@ -123,6 +123,9 @@
 		4BF2BCD6238A68CE00F70CDA /* VergeViewModelBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF2BCD5238A68CE00F70CDA /* VergeViewModelBase.swift */; };
 		4BF2BCE2238A85A700F70CDA /* VergeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF2BCE1238A85A700F70CDA /* VergeViewModelTests.swift */; };
 		4BF2BCE4238A85A700F70CDA /* VergeViewModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BF2BCA0238A63FB00F70CDA /* VergeViewModel.framework */; };
+		4BF470CD23CC36E8001A1D5D /* FragmentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF470CC23CC36E8001A1D5D /* FragmentState.swift */; };
+		4BF470D023CC394D001A1D5D /* CounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF470CE23CC3949001A1D5D /* CounterTests.swift */; };
+		4BF470D223CC3A43001A1D5D /* UpdatedMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF470D123CC3A43001A1D5D /* UpdatedMarker.swift */; };
 		4BFA22A023A63B56008D7BCB /* VergeCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BFA229E23A63B56008D7BCB /* VergeCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4BFA22A323A63B56008D7BCB /* VergeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BFA229C23A63B55008D7BCB /* VergeCore.framework */; };
 		4BFA22A423A63B56008D7BCB /* VergeCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4BFA229C23A63B55008D7BCB /* VergeCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -455,6 +458,9 @@
 		4BF2BCDF238A85A700F70CDA /* VergeViewModelTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VergeViewModelTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4BF2BCE1238A85A700F70CDA /* VergeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VergeViewModelTests.swift; sourceTree = "<group>"; };
 		4BF2BCE3238A85A700F70CDA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4BF470CC23CC36E8001A1D5D /* FragmentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FragmentState.swift; sourceTree = "<group>"; };
+		4BF470CE23CC3949001A1D5D /* CounterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterTests.swift; sourceTree = "<group>"; };
+		4BF470D123CC3A43001A1D5D /* UpdatedMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatedMarker.swift; sourceTree = "<group>"; };
 		4BFA229C23A63B55008D7BCB /* VergeCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VergeCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4BFA229E23A63B56008D7BCB /* VergeCore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VergeCore.h; sourceTree = "<group>"; };
 		4BFA229F23A63B56008D7BCB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -898,6 +904,7 @@
 				4BE9455323AD1B180060F977 /* Info.plist */,
 				4B39AE5423C5DC84005F7BC8 /* CopyPerformance.swift */,
 				4B4011C023C7831900C582BC /* GetterTests.swift */,
+				4BF470CE23CC3949001A1D5D /* CounterTests.swift */,
 			);
 			path = VergeCoreTests;
 			sourceTree = "<group>";
@@ -947,6 +954,8 @@
 				4B4011BE23C77CEC00C582BC /* Getter.swift */,
 				4B4DF7FF23A69CD800D53E9D /* ValueContainerType.swift */,
 				4BFA229F23A63B56008D7BCB /* Info.plist */,
+				4BF470CC23CC36E8001A1D5D /* FragmentState.swift */,
+				4BF470D123CC3A43001A1D5D /* UpdatedMarker.swift */,
 			);
 			path = VergeCore;
 			sourceTree = "<group>";
@@ -1748,6 +1757,7 @@
 				4B4011C123C7831900C582BC /* GetterTests.swift in Sources */,
 				4B39AE5623C5DC8D005F7BC8 /* CopyPerformance.swift in Sources */,
 				4BE9455B23AD1BBB0060F977 /* EventEmitterTests.swift in Sources */,
+				4BF470D023CC394D001A1D5D /* CounterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1773,6 +1783,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4BF470D223CC3A43001A1D5D /* UpdatedMarker.swift in Sources */,
+				4BF470CD23CC36E8001A1D5D /* FragmentState.swift in Sources */,
 				4BA3E1A523C359F40095629B /* Signpost.swift in Sources */,
 				4B4DF80023A69CD800D53E9D /* ValueContainerType.swift in Sources */,
 				4BFA22B323A63C38008D7BCB /* EventEmitter.swift in Sources */,

--- a/Verge.xcodeproj/xcshareddata/xcbaselines/4BE9454E23AD1B180060F977.xcbaseline/B5ED397D-1B21-4DBD-8112-C7F97A24DA6A.plist
+++ b/Verge.xcodeproj/xcshareddata/xcbaselines/4BE9454E23AD1B180060F977.xcbaseline/B5ED397D-1B21-4DBD-8112-C7F97A24DA6A.plist
@@ -47,6 +47,46 @@
 				</dict>
 			</dict>
 		</dict>
+		<key>CounterTests</key>
+		<dict>
+			<key>testCounterPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>2.8476e-05</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+				<key>com.apple.dt.XCTMetric_CPU.cycles</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>2120</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testGenCFDatePerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>1.1575e-05</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testGenDatePerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>1.3116e-05</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/Verge.xcworkspace/xcshareddata/xcschemes/All.xcscheme
+++ b/Verge.xcworkspace/xcshareddata/xcschemes/All.xcscheme
@@ -207,6 +207,11 @@
                BlueprintName = "VergeCoreTests"
                ReferencedContainer = "container:Verge.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "GetterTests/testChain()">
+               </Test>
+            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
## UpdatedMarker

Before this, Verge used Date to indicates state was updated.
However, generating Date may generate the same time during updating with high-frequency.
Therefore, it's been changed to UpdatedMarker that uses UInt64 inside with incrementing.

## Fragment<State>

In a single state tree, comparing for reducing the number of updates would be most important for keep performance.
However, implementing Equatable is not easy basically.
Instead, adding a like flag that indicates updated itself, it would be easy.
Actually, we need to get to flag that means **different**, it no need to be **equal**.

Now we can use Fragment struct that is a container for wrapping inside state up.
With dynamicMemberLookup, we can access the properties without new property.
Fragment has `UpdatedMarker`, we can compare if the state was updated with this.

```swift

struct YourState {
  var name: String = ...
}

struct AppState {

  var yourState: Fragment<YourState> = .init(.init())
}

appState.yourState.name // accessing with dynamic-member-lookup
```