### PR TITLE
New Syntax to create Getter

### DIFF
--- a/Sources/VergeCore/Comparers.swift
+++ b/Sources/VergeCore/Comparers.swift
@@ -21,40 +21,18 @@
 
 import Foundation
 
-public protocol Comparer {
-  associatedtype Input
+public struct Comparer<Input> {
   
-  /// Check if it uses input value
-  /// - Parameter input:
-  func equals(previousValue: Input, newValue: Input) -> Bool
-}
-
-extension Comparer {
-  public func asFunction() -> (Input, Input) -> Bool {
-    equals
-  }
-}
-
-public struct AnyComparer<Input>: Comparer {
   private let equals: (Input, Input) -> Bool
-  
+    
   public init(_ equals: @escaping (Input, Input) -> Bool) {
     self.equals = equals
   }
   
-  public func equals(previousValue: Input, newValue: Input) -> Bool {
-    equals(previousValue, newValue)
-  }
-}
-
-public struct CombinedComparer<Input>: Comparer {
-  
-  private let equals: (Input, Input) -> Bool
-  
-  public init(and comparers: [(Input, Input) -> Bool]) {
+  public init(and comparers: [Comparer<Input>]) {
     self.equals = { pre, new in
       for filter in comparers {
-        guard filter(pre, new) else {
+        guard filter.equals(previousValue: pre, newValue: new) else {
           return false
         }
       }
@@ -62,10 +40,10 @@ public struct CombinedComparer<Input>: Comparer {
     }
   }
   
-  public init(or comparers: [(Input, Input) -> Bool]) {
+  public init(or comparers: [Comparer<Input>]) {
     self.equals = { pre, new in
       for filter in comparers {
-        if filter(pre, new) {
+        if filter.equals(previousValue: pre, newValue: new) {
           return true
         }
       }
@@ -75,10 +53,6 @@ public struct CombinedComparer<Input>: Comparer {
   
   public func equals(previousValue: Input, newValue: Input) -> Bool {
     equals(previousValue, newValue)
-  }
-  
-  public func asAny() -> AnyComparer<Input> {
-    .init(equals)
   }
   
 }

--- a/Sources/VergeCore/EqualityComputer.swift
+++ b/Sources/VergeCore/EqualityComputer.swift
@@ -1,0 +1,86 @@
+//
+//  EqualityComputer.swift
+//  VergeCore
+//
+//  Created by muukii on 2020/01/31.
+//  Copyright © 2020 muukii. All rights reserved.
+//
+
+import Foundation
+
+fileprivate final class PreviousValueRef<T> {
+  var value: T?
+  init() {}
+}
+
+/// A Filter that compares with previous value.
+public final class EqualityComputer<Input> {
+  
+  private let _isEqual: (Input) -> Bool
+  
+  public init<Key, C: Comparer>(
+    selector: @escaping (Input) -> Key,
+    comparer: C
+  ) where C.Input == Key {
+    
+    let ref = PreviousValueRef<Key>()
+    
+    self._isEqual = { input in
+      
+      let key = selector(input)
+      defer {
+        ref.value = key
+      }
+      if let previousValue = ref.value {
+        return comparer.equals(previousValue: previousValue, newValue: key)
+      } else {
+        return false
+      }
+      
+    }
+    
+  }
+  
+  public func equals(input: Input) -> Bool {
+    _isEqual(input)
+  }
+  
+  public func registerFirstValue(_ value: Input) {
+    _ = _isEqual(value)
+  }
+  
+  public func asFunction() -> (Input) -> Bool {
+    equals
+  }
+  
+}
+
+public struct EqualityComputerBuilder<Input, ComparingKey> {
+  
+  public static var alwaysDifferent: EqualityComputerBuilder<Input, Input> {
+    .init(keySelector: { $0 }, comparer: { _, _ in false })
+  }
+  
+  let selector: (Input) -> ComparingKey
+  let predicate: (ComparingKey, ComparingKey) -> Bool
+  
+  public init(
+    keySelector: @escaping (Input) -> ComparingKey,
+    comparer: @escaping (ComparingKey, ComparingKey) -> Bool
+  ) {
+    self.selector = keySelector
+    self.predicate = comparer
+  }
+  
+  public func build() -> EqualityComputer<Input> {
+    .init(selector: selector, comparer: AnyComparer.init(predicate))
+  }
+}
+
+extension EqualityComputerBuilder where Input : Equatable {
+  
+  public static func make() -> EqualityComputerBuilder<Input, Input> {
+    .init(keySelector: { $0 }, comparer: ==)
+  }
+  
+}

--- a/Sources/VergeCore/Getter.swift
+++ b/Sources/VergeCore/Getter.swift
@@ -120,24 +120,4 @@ public final class GetterSource<Input, Output>: Getter<Output> {
   
 }
 
-extension Storage {
-  
-  @available(iOS 13, macOS 10.15, *)
-  public func makeGetter<Output>(
-    filter: @escaping (Value) -> Bool,
-    map: @escaping (Value) -> Output
-  ) -> GetterSource<Value, Output> {
-    
-    let pipe = publisher
-      .filter(filter)
-      .map(map)
-        
-    let makeGetter = GetterSource<Value, Output>.init(input: pipe)
-    
-    return makeGetter
-    
-  }
-  
-}
-
 #endif

--- a/Sources/VergeCore/GetterBuilder.swift
+++ b/Sources/VergeCore/GetterBuilder.swift
@@ -8,32 +8,160 @@
 
 import Foundation
 
-public struct GetterBuilder<Input, ComparingKey, Output> {
+public struct GetterBuilder<Input, PreComparingKey, Output, PostComparingKey> {
   
-  public let equalityComparerBuilder: EqualityComputerBuilder<Input, ComparingKey>
-  public let map: (Input) -> Output
-  
+  public let preFilter: EqualityComputerBuilder<Input, PreComparingKey>
+  public let transform: (Input) -> Output
+  public let postFilter: EqualityComputerBuilder<Output, PostComparingKey>?
+    
   public init(
-    preFilter: EqualityComputerBuilder<Input, ComparingKey>,
-    map: @escaping (Input) -> Output
+    preFilter: EqualityComputerBuilder<Input, PreComparingKey>,
+    transform: @escaping (Input) -> Output,
+    postFilter: EqualityComputerBuilder<Output, PostComparingKey>
   ) {
     
-    self.equalityComparerBuilder = preFilter
-    self.map = map
+    self.preFilter = preFilter
+    self.transform = transform
+    self.postFilter = postFilter
     
   }
   
-}
-
-extension GetterBuilder where Input : Equatable {
-  
-  public static func make<Output>(map: @escaping (Input) -> Output) -> GetterBuilder<Input, Input, Output> {
-    .init(preFilter: .init(keySelector: { $0 }, comparer: ==), map: map)
-  }
-      
 }
 
 extension GetterBuilder {
-     
+  
+  public static func make(
+    preFilter: EqualityComputerBuilder<Input, PreComparingKey>,
+    transform: @escaping (Input) -> Output
+  ) -> GetterBuilder<Input, PreComparingKey, Output, Output> {
+    
+    return .init(
+      preFilter: preFilter,
+      transform: transform,
+      postFilter: .noFilter
+    )
+    
+  }
+  
+  public static func from(_ fragment: GetterBuilderTransformMethodChain<Input, PreComparingKey, Output>) -> GetterBuilder<Input, PreComparingKey, Output, Output> {
+    
+    let f = fragment
+    
+    return .init(
+      preFilter: f.preFilterFragment.preFilter,
+      transform: f.transform,
+      postFilter: .noFilter
+    )
+    
+  }
+  
+  public static func from(_ fragment: GetterBuilderPostFilterMethodChain<Input, PreComparingKey, Output, PostComparingKey>) -> GetterBuilder<Input, PreComparingKey, Output, PostComparingKey> {
+    
+    let f = fragment
+    
+    return .init(
+      preFilter: f.transformFragment.preFilterFragment.preFilter,
+      transform: f.transformFragment.transform,
+      postFilter: f.postFilter
+    )
+    
+  }
+  
 }
+
+// MARK: - Method Chain
+
+public struct GetterBuilderMethodChain<Input> {
+  
+  public init() {}
+  
+  public func preFilter<PreComparingKey>(
+    _ preFilter: EqualityComputerBuilder<Input, PreComparingKey>
+  ) -> GetterBuilderPreFilterMethodChain<Input, PreComparingKey> {
+    .init(preFilter: preFilter)
+  }
+  
+  public func preFilter<PreComparingKey>(
+    keySelector: KeyPath<Input, PreComparingKey>,
+    comparer: Comparer<PreComparingKey>
+  )-> GetterBuilderPreFilterMethodChain<Input, PreComparingKey> {
+    preFilter(.init(keySelector: keySelector, comparer: comparer))
+  }
+  
+  public func preFilter(
+    comparer: Comparer<Input>
+  )-> GetterBuilderPreFilterMethodChain<Input, Input> {
+    preFilter(keySelector: \.self, comparer: comparer)
+  }
+  
+}
+
+public struct GetterBuilderPreFilterMethodChain<Input, PreComparingKey> {
+  
+  let preFilter: EqualityComputerBuilder<Input, PreComparingKey>
+  
+  init(
+    preFilter: EqualityComputerBuilder<Input, PreComparingKey>
+  ) {
+    self.preFilter = preFilter
+  }
+  
+  public func map<Output>(_ transform: @escaping (Input) -> Output) -> GetterBuilderTransformMethodChain<Input, PreComparingKey, Output> {
+    return .init(source: self, transform: transform)
+  }
+  
+  public func map<Output>(_ transform: KeyPath<Input, Output>) -> GetterBuilderTransformMethodChain<Input, PreComparingKey, Output> {
+    return .init(source: self, transform: { $0[keyPath: transform] })
+  }
+}
+
+public struct GetterBuilderTransformMethodChain<Input, PreComparingkey, Output> {
+  
+  let preFilterFragment: GetterBuilderPreFilterMethodChain<Input, PreComparingkey>
+  let transform: (Input) -> Output
+  
+  init(
+    source: GetterBuilderPreFilterMethodChain<Input, PreComparingkey>,
+    transform: @escaping (Input) -> Output
+  ) {
+    self.preFilterFragment = source
+    self.transform = transform
+  }
+  
+  public func postFilter<PostComparingKey>(
+    _ postFilter: EqualityComputerBuilder<Output, PostComparingKey>
+  ) -> GetterBuilderPostFilterMethodChain<Input, PreComparingkey, Output, PostComparingKey> {
+    return .init(source: self, postFilter: postFilter)
+  }
+  
+  public func postFilter<PostComparingKey>(
+    keySelector: KeyPath<Output, PostComparingKey>,
+    comparer: Comparer<PostComparingKey>
+  )-> GetterBuilderPostFilterMethodChain<Input, PreComparingkey, Output, PostComparingKey> {
+    return postFilter(.init(keySelector: keySelector, comparer: comparer))
+  }
+  
+  public func postFilter(
+    comparer: Comparer<Output>
+  )-> GetterBuilderPostFilterMethodChain<Input, PreComparingkey, Output, Output> {
+    return postFilter(.init(keySelector: \.self, comparer: comparer))
+  }
+  
+}
+
+public struct GetterBuilderPostFilterMethodChain<Input, PreComparingkey, Output, PostComparingKey> {
+  
+  let transformFragment: GetterBuilderTransformMethodChain<Input, PreComparingkey, Output>
+  let postFilter: EqualityComputerBuilder<Output, PostComparingKey>
+  
+  init(
+    source: GetterBuilderTransformMethodChain<Input, PreComparingkey, Output>,
+    postFilter: EqualityComputerBuilder<Output, PostComparingKey>
+  ) {
+    self.transformFragment = source
+    self.postFilter = postFilter
+  }
+  
+}
+
 

--- a/Sources/VergeCore/GetterBuilder.swift
+++ b/Sources/VergeCore/GetterBuilder.swift
@@ -8,42 +8,32 @@
 
 import Foundation
 
-public struct EqualityComparerBuilder<Input, ComparingKey> {
-  
-  public static var alwaysDifferent: EqualityComparerBuilder<Input, Input> {
-    .init(selector: { $0 }, predicate: { _, _ in false })
-  }
-  
-  let selector: (Input) -> ComparingKey
-  let predicate: (ComparingKey, ComparingKey) -> Bool
-  
-  public init(
-    selector: @escaping (Input) -> ComparingKey,
-    predicate: @escaping (ComparingKey, ComparingKey) -> Bool
-  ) {
-    self.selector = selector
-    self.predicate = predicate
-  }
-  
-  public func build() -> HistoricalComparer<Input> {
-    .init(selector: selector, comparer: AnyComparerFragment.init(predicate))
-  }
-}
-
 public struct GetterBuilder<Input, ComparingKey, Output> {
   
-  public let equalityComparerBuilder: EqualityComparerBuilder<Input, ComparingKey>
+  public let equalityComparerBuilder: EqualityComputerBuilder<Input, ComparingKey>
   public let map: (Input) -> Output
   
   public init(
-    equalityComparerBuilder: EqualityComparerBuilder<Input, ComparingKey>,
+    preFilter: EqualityComputerBuilder<Input, ComparingKey>,
     map: @escaping (Input) -> Output
   ) {
     
-    self.equalityComparerBuilder = equalityComparerBuilder
+    self.equalityComparerBuilder = preFilter
     self.map = map
     
   }
   
+}
+
+extension GetterBuilder where Input : Equatable {
+  
+  public static func make<Output>(map: @escaping (Input) -> Output) -> GetterBuilder<Input, Input, Output> {
+    .init(preFilter: .init(keySelector: { $0 }, comparer: ==), map: map)
+  }
+      
+}
+
+extension GetterBuilder {
+     
 }
 

--- a/Sources/VergeCore/ValueContainerType.swift
+++ b/Sources/VergeCore/ValueContainerType.swift
@@ -19,20 +19,65 @@ public protocol ValueContainerType: AnyObject {
   #if canImport(Combine)
      
   @available(iOS 13, macOS 10.15, *)
-  func makeGetter<ComparingKey, Output>(
-    from builder: GetterBuilder<Value, ComparingKey, Output>
+  func makeGetter<PreComparingKey, Output, PostComparingKey>(
+    from builder: GetterBuilder<Value, PreComparingKey, Output, PostComparingKey>
   ) -> GetterSource<Value, Output>
   
   #endif
 }
 
 #if canImport(Combine)
+import Combine
 extension ValueContainerType {
+    
+  /// Dummy
+  @available(*, deprecated, message: "Dummy method")
+  @available(iOS 13, macOS 10.15, *)
+  public func makeGetter(_ make: (GetterBuilderMethodChain<Value>) -> Never) -> Never {
+    fatalError()
+  }
+  
+  /// Dummy
+  @available(*, deprecated, message: "You need to call `map` more. This is Dummy method")
+  @available(iOS 13, macOS 10.15, *)
+  public func makeGetter<PreComparingKey>(_ make: (GetterBuilderMethodChain<Value>) -> GetterBuilderPreFilterMethodChain<Value, PreComparingKey>) -> Never {
+    fatalError()
+  }
+  
+  /// Value -> [PreFilter -> Transform] -> Value
+  @available(iOS 13, macOS 10.15, *)
+  public func makeGetter<PreComparingKey, Output>(_ make: (GetterBuilderMethodChain<Value>) -> GetterBuilderTransformMethodChain<Value, PreComparingKey, Output>) -> GetterSource<Value, Output> {
+    return makeGetter(from: .from(make(.init())))
+  }
+  
+  /// Value -> [PreFilter -> Transform -> PostFilter] -> Value
+  @available(iOS 13, macOS 10.15, *)
+  public func makeGetter<PreComparingKey, Output, PostComparingKey>(_ make: (GetterBuilderMethodChain<Value>) -> GetterBuilderPostFilterMethodChain<Value, PreComparingKey, Output, PostComparingKey>) -> GetterSource<Value, Output> {
+    return makeGetter(from: .from(make(.init())))
+  }
   
   @available(iOS 13, macOS 10.15, *)
-  public func makeGetter() -> GetterSource<Value, Value> {
-    makeGetter(from: .init(preFilter: .alwaysDifferent, map: { $0 }))
+  public func makeGetter<Output>(map: @escaping (Value) -> Output) -> GetterSource<Value, Output> where Output : Equatable {
+    makeGetter {
+      $0.preFilter(.noFilter)
+        .map(map)
+        .postFilter(comparer: .init(==))
+    }
   }
+  
+  @available(iOS 13, macOS 10.15, *)
+  public func makeGetter<Output>(map keyPath: KeyPath<Value, Output>) -> GetterSource<Value, Output> where Output : Equatable {
+    makeGetter(map: { $0[keyPath: keyPath] })
+  }
+  
+  @available(iOS 13, macOS 10.15, *)
+  public func makeGetter<PreComparingKey>(preFilter:  EqualityComputerBuilder<Value, PreComparingKey>) -> GetterSource<Value, Value> {
+    makeGetter {
+      $0.preFilter(preFilter)
+        .map { $0 }
+    }
+  }
+  
 }
 #endif
 
@@ -50,17 +95,30 @@ extension Storage: ValueContainerType {
   
   @available(iOS 13, macOS 10.15, *)
   
-  public func makeGetter<ComparingKey, Output>(
-    from builder: GetterBuilder<Value, ComparingKey, Output>
+  public func makeGetter<PreComparingKey, Output, PostComparingKey>(
+    from builder: GetterBuilder<Value, PreComparingKey, Output, PostComparingKey>
   ) -> GetterSource<Value, Output> {
     
-    let comparer = builder.equalityComparerBuilder.build()
-    let pipe = publisher
-      .filter { value in
-        !comparer.equals(input: value)
-    }
-    .map(builder.map)
+    let preComparer = builder.preFilter.build()
+    let postComparer = builder.postFilter?.build()
     
+    let base = publisher
+      .filter { value in
+        !preComparer.equals(input: value)
+    }
+    .map(builder.transform)
+    
+    let pipe: AnyPublisher<Output, Never>
+    
+    if let comparer = postComparer {
+      pipe = base.filter { value in
+        !comparer.equals(input: value)
+      }
+      .eraseToAnyPublisher()
+    } else {
+      pipe = base.eraseToAnyPublisher()
+    }
+       
     let makeGetter = GetterSource<Value, Output>.init(input: pipe)
     
     return makeGetter

--- a/Sources/VergeCore/ValueContainerType.swift
+++ b/Sources/VergeCore/ValueContainerType.swift
@@ -31,7 +31,7 @@ extension ValueContainerType {
   
   @available(iOS 13, macOS 10.15, *)
   public func makeGetter() -> GetterSource<Value, Value> {
-    makeGetter(from: .init(equalityComparerBuilder: .alwaysDifferent, map: { $0 }))
+    makeGetter(from: .init(preFilter: .alwaysDifferent, map: { $0 }))
   }
 }
 #endif

--- a/Sources/VergeORM/Storage+Getter.swift
+++ b/Sources/VergeORM/Storage+Getter.swift
@@ -49,52 +49,39 @@ public protocol DatabaseEmbedding {
   
 }
 
-extension Filters.Historical where Input : DatabaseType {
+extension AnyComparerFragment where Input : DatabaseType {
   
   public static func databaseUpdated() -> Self {
-    .init(
-      selector: { input -> (UpdatedMarker, UpdatedMarker) in
-        let v = input
-        return (v._backingStorage.entityUpdatedMarker, v._backingStorage.indexUpdatedMarker)
-    },
-      predicate: { (old, new) -> Bool in
-        old != new
-    })
+    return .init { pre, new in
+      (pre._backingStorage.entityUpdatedMarker, pre._backingStorage.indexUpdatedMarker) == (new._backingStorage.entityUpdatedMarker, new._backingStorage.indexUpdatedMarker)
+    }
   }
   
   public static func tableUpdated<E: EntityType>(_ entityType: E.Type) -> Self {
-    return .init(
-      selector: { input -> UpdatedMarker in
-        return input._backingStorage.entityBackingStorage.table(E.self).updatedMarker
-    },
-      predicate: { (old, new) -> Bool in
-        old != new
-    })
+    return .init { pre, new in
+      pre._backingStorage.entityBackingStorage.table(E.self).updatedMarker == new._backingStorage.entityBackingStorage.table(E.self).updatedMarker
+    }
   }
   
   public static func entityUpdated<E: EntityType & Equatable>(_ entityID: E.EntityID) -> Self {
-    return .init(
-      selector: { db in db.entities.table(E.self).find(by: entityID) },
-      predicate: {
-        $0 != $1
-    })
+    return .init { pre, new in
+      pre.entities.table(E.self).find(by: entityID) == new.entities.table(E.self).find(by: entityID)
+    }
   }
   
   public static func changesContains<E: EntityType>(_ entityID: E.EntityID) -> Self {
-    return .init(
-      selector: { $0 },
-      predicate: { _, db -> Bool in
-        guard let result = db._backingStorage.lastUpdatesResult else {
-          return true
-        }
-        guard !result.wasUpdated(entityID) else {
-          return true
-        }
-        guard !result.wasDeleted(entityID) else {
-          return true
-        }
+    return .init { _, new in
+      guard let result = new._backingStorage.lastUpdatesResult else {
         return false
-    })
+      }
+      guard !result.wasUpdated(entityID) else {
+        return false
+      }
+      guard !result.wasDeleted(entityID) else {
+        return false
+      }
+      return true
+    }
   }
   
 }
@@ -122,53 +109,54 @@ extension GetterBuilder where Input : DatabaseEmbedding {
   
   public static func makeEntityGetter<Output>(
     update: @escaping (Input.Database) -> Output,
-    andFilter: ((Input.Database) -> Bool)?
-  ) -> GetterBuilder<Input, Output> {
+    andFilter: AnyComparerFragment<Input.Database>?
+  ) -> GetterBuilder<Input, Input.Database, Output> {
     
     let path = Input.getterToDatabase
     
-    let filter = Filters.Combined<Input.Database>.init(and: [
-      Filters.Historical.databaseUpdated().asFunction(),
-      andFilter
+    let filter = CombinedComparerFragment<Input.Database>.init(or: [
+      AnyComparerFragment.databaseUpdated().asFunction(),
+      andFilter?.asFunction()
       ].compactMap { $0 })
     
     return .init(
-      filter: Filters.Basic { input in
-        filter.check(input: path(input))
-      }.asFunction(),
-      map:  { (value) -> Output in
-        let t = VergeSignpostTransaction("ORM.Getter.update")
-        defer {
-          t.end()
-        }
-        return update(Input.getterToDatabase(value))
+      equalityComparerBuilder: .init(
+        selector: { path($0) },
+        predicate: filter.asFunction()
+      ),
+      map: { (value) -> Output in
+      let t = VergeSignpostTransaction("ORM.Getter.update")
+      defer {
+        t.end()
+      }
+      return update(Input.getterToDatabase(value))
     })
-   
+         
   }
   
   public static func makeEntityGetter<E: EntityType>(
     from entityID: E.EntityID,
-    andFilter: ((Input.Database) -> Bool)?
-  ) -> GetterBuilder<Input, E?> {
+    andFilter: AnyComparerFragment<Input.Database>?
+  ) -> GetterBuilder<Input, Input.Database, E?> {
     
     return makeEntityGetter(
       update: { db in
         db.entities.table(E.self).find(by: entityID)
     },
-      andFilter: Filters.Combined.init(and: [
-        Filters.Historical.tableUpdated(E.self).asFunction(),
-        Filters.Historical.changesContains(entityID).asFunction(),
-        andFilter
+      andFilter: CombinedComparerFragment.init(or: [
+        AnyComparerFragment.tableUpdated(E.self).asFunction(),
+        AnyComparerFragment.changesContains(entityID).asFunction(),
+        andFilter?.asFunction()
         ].compactMap { $0 }
-      ).asFunction()
+      ).asAny()
     )
         
   }
   
   public static func makeNonNullEntityGetter<E: EntityType>(
     from entity: E,
-    andFilter: ((Input.Database) -> Bool)?
-  ) -> GetterBuilder<Input, E> {
+    andFilter: AnyComparerFragment<Input.Database>?
+  ) -> GetterBuilder<Input, Input.Database, E> {
     
     var box = entity
     let entityID = entity.entityID
@@ -181,12 +169,12 @@ extension GetterBuilder where Input : DatabaseEmbedding {
         }
         return box
     },
-      andFilter: Filters.Combined.init(and: [
-        Filters.Historical.tableUpdated(E.self).asFunction(),
-        Filters.Historical.changesContains(entityID).asFunction(),
-        andFilter
+      andFilter: CombinedComparerFragment.init(or: [
+        AnyComparerFragment.tableUpdated(E.self).asFunction(),
+        AnyComparerFragment.changesContains(entityID).asFunction(),
+        andFilter?.asFunction()
         ].compactMap { $0 }
-      ).asFunction()
+      ).asAny()
     )
     return newGetter
     
@@ -222,7 +210,7 @@ extension ValueContainerType where Value : DatabaseEmbedding {
   ///   - andFilter: Check to necessory of needs to update to reduce number of updating.
   public func makeEntityGetter<Output>(
     update: @escaping (Value.Database) -> Output,
-    andFilter: ((Value.Database) -> Bool)?
+    andFilter: AnyComparerFragment<Value.Database>?
   ) -> GetterSource<Value, Output> {
       
     return makeGetter(from: .makeEntityGetter(update: update, andFilter: andFilter))
@@ -230,7 +218,7 @@ extension ValueContainerType where Value : DatabaseEmbedding {
   
   public func makeEntityGetter<E: EntityType>(
     from entityID: E.EntityID,
-    andFilter: ((Value.Database) -> Bool)?
+    andFilter: AnyComparerFragment<Value.Database>?
   ) -> GetterSource<Value, E?> {
     
     return makeGetter(from: .makeEntityGetter(from: entityID, andFilter: andFilter))
@@ -238,7 +226,7 @@ extension ValueContainerType where Value : DatabaseEmbedding {
   
   public func makeNonNullEntityGetter<E: EntityType>(
     from entity: E,
-    andFilter: ((Value.Database) -> Bool)?
+    andFilter: AnyComparerFragment<Value.Database>?
   ) -> GetterSource<Value, E> {
     
     return makeGetter(from: .makeNonNullEntityGetter(from: entity, andFilter: andFilter))
@@ -271,7 +259,7 @@ extension ValueContainerType where Value : DatabaseEmbedding {
     let _cache = cache
     
     guard let makeGetter = _cache.getter(entityID: entityID) as? GetterSource<Value, E?> else {
-      let newGetter = makeEntityGetter(from: entityID, andFilter: Filters.Historical.entityUpdated(entityID).asFunction())
+      let newGetter = makeEntityGetter(from: entityID, andFilter: AnyComparerFragment.entityUpdated(entityID))
       _cache.setGetter(newGetter, entityID: entityID)
       return newGetter
     }
@@ -305,7 +293,7 @@ extension ValueContainerType where Value : DatabaseEmbedding {
     
     guard let makeGetter = _cache.getter(entityID: entity.entityID) as? GetterSource<Value, E> else {
       let entityID = entity.entityID
-      let newGetter = makeNonNullEntityGetter(from: entity, andFilter: Filters.Historical.entityUpdated(entityID).asFunction())
+      let newGetter = makeNonNullEntityGetter(from: entity, andFilter: AnyComparerFragment.entityUpdated(entityID))
       _cache.setGetter(newGetter, entityID: entityID)
       return newGetter
     }

--- a/Sources/VergeORM/Storage+Getter.swift
+++ b/Sources/VergeORM/Storage+Getter.swift
@@ -49,7 +49,7 @@ public protocol DatabaseEmbedding {
   
 }
 
-extension AnyComparer where Input : DatabaseType {
+extension Comparer where Input : DatabaseType {
   
   public static func databaseUpdated() -> Self {
     return .init { pre, new in
@@ -109,54 +109,54 @@ extension GetterBuilder where Input : DatabaseEmbedding {
   
   public static func makeEntityGetter<Output>(
     update: @escaping (Input.Database) -> Output,
-    andFilter: AnyComparer<Input.Database>?
-  ) -> GetterBuilder<Input, Input.Database, Output> {
+    andFilter: Comparer<Input.Database>?
+  ) -> GetterBuilder<Input, Input.Database, Output, Output> {
     
     let path = Input.getterToDatabase
     
-    let filter = CombinedComparer<Input.Database>.init(or: [
-      AnyComparer.databaseUpdated().asFunction(),
-      andFilter?.asFunction()
+    let filter = Comparer<Input.Database>.init(or: [
+      .databaseUpdated(),
+      andFilter
       ].compactMap { $0 })
     
-    return .init(
+    return .make(
       preFilter: .init(
         keySelector: { path($0) },
-        comparer: filter.asFunction()
+        comparer: filter
       ),
-      map: { (value) -> Output in
-      let t = VergeSignpostTransaction("ORM.Getter.update")
-      defer {
-        t.end()
-      }
-      return update(Input.getterToDatabase(value))
+      transform: { (value) -> Output in
+        let t = VergeSignpostTransaction("ORM.Getter.update")
+        defer {
+          t.end()
+        }
+        return update(Input.getterToDatabase(value))
     })
-         
+    
   }
   
   public static func makeEntityGetter<E: EntityType>(
     from entityID: E.EntityID,
-    andFilter: AnyComparer<Input.Database>?
-  ) -> GetterBuilder<Input, Input.Database, E?> {
+    andFilter: Comparer<Input.Database>?
+  ) -> GetterBuilder<Input, Input.Database, E?, E?> {
     
     return makeEntityGetter(
       update: { db in
         db.entities.table(E.self).find(by: entityID)
     },
-      andFilter: CombinedComparer.init(or: [
-        AnyComparer.tableUpdated(E.self).asFunction(),
-        AnyComparer.changesContains(entityID).asFunction(),
-        andFilter?.asFunction()
+      andFilter: .init(or: [
+        .tableUpdated(E.self),
+        .changesContains(entityID),
+        andFilter
         ].compactMap { $0 }
-      ).asAny()
+      )
     )
         
   }
   
   public static func makeNonNullEntityGetter<E: EntityType>(
     from entity: E,
-    andFilter: AnyComparer<Input.Database>?
-  ) -> GetterBuilder<Input, Input.Database, E> {
+    andFilter: Comparer<Input.Database>?
+  ) -> GetterBuilder<Input, Input.Database, E, E> {
     
     var box = entity
     let entityID = entity.entityID
@@ -169,12 +169,12 @@ extension GetterBuilder where Input : DatabaseEmbedding {
         }
         return box
     },
-      andFilter: CombinedComparer.init(or: [
-        AnyComparer.tableUpdated(E.self).asFunction(),
-        AnyComparer.changesContains(entityID).asFunction(),
-        andFilter?.asFunction()
+      andFilter: Comparer.init(or: [
+        .tableUpdated(E.self),
+        .changesContains(entityID),
+        andFilter
         ].compactMap { $0 }
-      ).asAny()
+      )
     )
     return newGetter
     
@@ -210,7 +210,7 @@ extension ValueContainerType where Value : DatabaseEmbedding {
   ///   - andFilter: Check to necessory of needs to update to reduce number of updating.
   public func makeEntityGetter<Output>(
     update: @escaping (Value.Database) -> Output,
-    andFilter: AnyComparer<Value.Database>?
+    andFilter: Comparer<Value.Database>?
   ) -> GetterSource<Value, Output> {
       
     return makeGetter(from: .makeEntityGetter(update: update, andFilter: andFilter))
@@ -218,7 +218,7 @@ extension ValueContainerType where Value : DatabaseEmbedding {
   
   public func makeEntityGetter<E: EntityType>(
     from entityID: E.EntityID,
-    andFilter: AnyComparer<Value.Database>?
+    andFilter: Comparer<Value.Database>?
   ) -> GetterSource<Value, E?> {
     
     return makeGetter(from: .makeEntityGetter(from: entityID, andFilter: andFilter))
@@ -226,7 +226,7 @@ extension ValueContainerType where Value : DatabaseEmbedding {
   
   public func makeNonNullEntityGetter<E: EntityType>(
     from entity: E,
-    andFilter: AnyComparer<Value.Database>?
+    andFilter: Comparer<Value.Database>?
   ) -> GetterSource<Value, E> {
     
     return makeGetter(from: .makeNonNullEntityGetter(from: entity, andFilter: andFilter))
@@ -259,7 +259,7 @@ extension ValueContainerType where Value : DatabaseEmbedding {
     let _cache = cache
     
     guard let makeGetter = _cache.getter(entityID: entityID) as? GetterSource<Value, E?> else {
-      let newGetter = makeEntityGetter(from: entityID, andFilter: AnyComparer.entityUpdated(entityID))
+      let newGetter = makeEntityGetter(from: entityID, andFilter: Comparer.entityUpdated(entityID))
       _cache.setGetter(newGetter, entityID: entityID)
       return newGetter
     }
@@ -293,7 +293,7 @@ extension ValueContainerType where Value : DatabaseEmbedding {
     
     guard let makeGetter = _cache.getter(entityID: entity.entityID) as? GetterSource<Value, E> else {
       let entityID = entity.entityID
-      let newGetter = makeNonNullEntityGetter(from: entity, andFilter: AnyComparer.entityUpdated(entityID))
+      let newGetter = makeNonNullEntityGetter(from: entity, andFilter: Comparer.entityUpdated(entityID))
       _cache.setGetter(newGetter, entityID: entityID)
       return newGetter
     }

--- a/Sources/VergeRx/ORM/EntityGetter.swift
+++ b/Sources/VergeRx/ORM/EntityGetter.swift
@@ -37,7 +37,7 @@ fileprivate final class _GetterCache {
 fileprivate var _valueContainerAssociated: Void?
 
 extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbedding {
-  
+        
   private var cache: _GetterCache {
     
     if let associated = objc_getAssociatedObject(base, &_valueContainerAssociated) as? _GetterCache {
@@ -58,9 +58,9 @@ extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbed
   ///   - update: Updating output value each Input value updated.
   ///   - andFilter: Check to necessory of needs to update to reduce number of updating.
   public func makeEntityGetter<Output>(
-    update: @escaping (Base.Value.Database) -> Output,
-    andFilter: AnyComparer<Base.Value.Database>?
-  ) -> RxGetterSource<Base.Value, Output> {
+    update: @escaping (Value.Database) -> Output,
+    andFilter: Comparer<Value.Database>?
+  ) -> RxGetterSource<Value, Output> {
     
     return makeGetter(from: .makeEntityGetter(update: update, andFilter: andFilter))
     
@@ -68,16 +68,16 @@ extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbed
   
   public func makeEntityGetter<E: EntityType>(
     from entityID: E.EntityID,
-    andFilter: AnyComparer<Base.Value.Database>?
-  ) -> RxGetterSource<Base.Value, E?> {
+    andFilter: Comparer<Value.Database>?
+  ) -> RxGetterSource<Value, E?> {
     
     return makeGetter(from: .makeEntityGetter(from: entityID, andFilter: andFilter))
   }
   
   public func makeNonNullEntityGetter<E: EntityType>(
     from entity: E,
-    andFilter: AnyComparer<Base.Value.Database>?
-  ) -> RxGetterSource<Base.Value, E> {
+    andFilter: Comparer<Value.Database>?
+  ) -> RxGetterSource<Value, E> {
     
     return makeGetter(from: .makeNonNullEntityGetter(from: entity, andFilter: andFilter))
   }
@@ -88,7 +88,7 @@ extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbed
   /// - Parameters:
   ///   - tableSelector:
   ///   - entityID:
-  public func entityGetter<E: EntityType>(from entityID: E.EntityID) -> RxGetterSource<Base.Value, E?> {
+  public func entityGetter<E: EntityType>(from entityID: E.EntityID) -> RxGetterSource<Value, E?> {
     
     let _cache = cache
     
@@ -104,12 +104,12 @@ extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbed
   
   public func entityGetter<E: EntityType & Equatable>(
     from entityID: E.EntityID
-  ) -> RxGetterSource<Base.Value, E?> {
+  ) -> RxGetterSource<Value, E?> {
     
     let _cache = cache
     
     guard let getter = _cache.getter(entityID: entityID) as? RxGetterSource<Base.Value, E?> else {
-      let newGetter = makeEntityGetter(from: entityID, andFilter: AnyComparer.entityUpdated(entityID))
+      let newGetter = makeEntityGetter(from: entityID, andFilter: .entityUpdated(entityID))
       _cache.setGetter(newGetter, entityID: entityID)
       return newGetter
     }
@@ -143,7 +143,7 @@ extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbed
     
     guard let getter = _cache.getter(entityID: entity.entityID) as? RxGetterSource<Base.Value, E> else {
       let entityID = entity.entityID
-      let newGetter = makeNonNullEntityGetter(from: entity, andFilter: AnyComparer.entityUpdated(entityID))
+      let newGetter = makeNonNullEntityGetter(from: entity, andFilter: .entityUpdated(entityID))
       _cache.setGetter(newGetter, entityID: entityID)
       return newGetter
     }

--- a/Sources/VergeRx/ORM/EntityGetter.swift
+++ b/Sources/VergeRx/ORM/EntityGetter.swift
@@ -59,7 +59,7 @@ extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbed
   ///   - andFilter: Check to necessory of needs to update to reduce number of updating.
   public func makeEntityGetter<Output>(
     update: @escaping (Base.Value.Database) -> Output,
-    andFilter: ((Base.Value.Database) -> Bool)?
+    andFilter: AnyComparerFragment<Base.Value.Database>?
   ) -> RxGetterSource<Base.Value, Output> {
     
     return makeGetter(from: .makeEntityGetter(update: update, andFilter: andFilter))
@@ -68,7 +68,7 @@ extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbed
   
   public func makeEntityGetter<E: EntityType>(
     from entityID: E.EntityID,
-    andFilter: ((Base.Value.Database) -> Bool)?
+    andFilter: AnyComparerFragment<Base.Value.Database>?
   ) -> RxGetterSource<Base.Value, E?> {
     
     return makeGetter(from: .makeEntityGetter(from: entityID, andFilter: andFilter))
@@ -76,7 +76,7 @@ extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbed
   
   public func makeNonNullEntityGetter<E: EntityType>(
     from entity: E,
-    andFilter: ((Base.Value.Database) -> Bool)?
+    andFilter: AnyComparerFragment<Base.Value.Database>?
   ) -> RxGetterSource<Base.Value, E> {
     
     return makeGetter(from: .makeNonNullEntityGetter(from: entity, andFilter: andFilter))
@@ -109,7 +109,7 @@ extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbed
     let _cache = cache
     
     guard let getter = _cache.getter(entityID: entityID) as? RxGetterSource<Base.Value, E?> else {
-      let newGetter = makeEntityGetter(from: entityID, andFilter: Filters.Historical.entityUpdated(entityID).asFunction())
+      let newGetter = makeEntityGetter(from: entityID, andFilter: AnyComparerFragment.entityUpdated(entityID))
       _cache.setGetter(newGetter, entityID: entityID)
       return newGetter
     }
@@ -143,7 +143,7 @@ extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbed
     
     guard let getter = _cache.getter(entityID: entity.entityID) as? RxGetterSource<Base.Value, E> else {
       let entityID = entity.entityID
-      let newGetter = makeNonNullEntityGetter(from: entity, andFilter: Filters.Historical.entityUpdated(entityID).asFunction())
+      let newGetter = makeNonNullEntityGetter(from: entity, andFilter: AnyComparerFragment.entityUpdated(entityID))
       _cache.setGetter(newGetter, entityID: entityID)
       return newGetter
     }

--- a/Sources/VergeRx/ORM/EntityGetter.swift
+++ b/Sources/VergeRx/ORM/EntityGetter.swift
@@ -59,7 +59,7 @@ extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbed
   ///   - andFilter: Check to necessory of needs to update to reduce number of updating.
   public func makeEntityGetter<Output>(
     update: @escaping (Base.Value.Database) -> Output,
-    andFilter: AnyComparerFragment<Base.Value.Database>?
+    andFilter: AnyComparer<Base.Value.Database>?
   ) -> RxGetterSource<Base.Value, Output> {
     
     return makeGetter(from: .makeEntityGetter(update: update, andFilter: andFilter))
@@ -68,7 +68,7 @@ extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbed
   
   public func makeEntityGetter<E: EntityType>(
     from entityID: E.EntityID,
-    andFilter: AnyComparerFragment<Base.Value.Database>?
+    andFilter: AnyComparer<Base.Value.Database>?
   ) -> RxGetterSource<Base.Value, E?> {
     
     return makeGetter(from: .makeEntityGetter(from: entityID, andFilter: andFilter))
@@ -76,7 +76,7 @@ extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbed
   
   public func makeNonNullEntityGetter<E: EntityType>(
     from entity: E,
-    andFilter: AnyComparerFragment<Base.Value.Database>?
+    andFilter: AnyComparer<Base.Value.Database>?
   ) -> RxGetterSource<Base.Value, E> {
     
     return makeGetter(from: .makeNonNullEntityGetter(from: entity, andFilter: andFilter))
@@ -109,7 +109,7 @@ extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbed
     let _cache = cache
     
     guard let getter = _cache.getter(entityID: entityID) as? RxGetterSource<Base.Value, E?> else {
-      let newGetter = makeEntityGetter(from: entityID, andFilter: AnyComparerFragment.entityUpdated(entityID))
+      let newGetter = makeEntityGetter(from: entityID, andFilter: AnyComparer.entityUpdated(entityID))
       _cache.setGetter(newGetter, entityID: entityID)
       return newGetter
     }
@@ -143,7 +143,7 @@ extension Reactive where Base : RxValueContainerType, Base.Value : DatabaseEmbed
     
     guard let getter = _cache.getter(entityID: entity.entityID) as? RxGetterSource<Base.Value, E> else {
       let entityID = entity.entityID
-      let newGetter = makeNonNullEntityGetter(from: entity, andFilter: AnyComparerFragment.entityUpdated(entityID))
+      let newGetter = makeNonNullEntityGetter(from: entity, andFilter: AnyComparer.entityUpdated(entityID))
       _cache.setGetter(newGetter, entityID: entityID)
       return newGetter
     }

--- a/Sources/VergeRx/RxGetter.swift
+++ b/Sources/VergeRx/RxGetter.swift
@@ -121,15 +121,15 @@ extension Reactive where Base : RxValueContainerType {
   
   public func makeGetter<ComparingKey, Output>(
     map: @escaping (Base.Value) -> Output,
-    equalityComparer: EqualityComparerBuilder<Base.Value, ComparingKey>
+    equalityComparer: EqualityComputerBuilder<Base.Value, ComparingKey>
   ) -> RxGetterSource<Base.Value, Output> {
     
-    makeGetter(from: .init(equalityComparerBuilder:equalityComparer, map:map))
+    makeGetter(from: .init(preFilter:equalityComparer, map:map))
     
   }
     
   public func makeGetter() -> RxGetterSource<Base.Value, Base.Value> {
-    makeGetter(from: .init(equalityComparerBuilder: .alwaysDifferent, map: { $0 }))
+    makeGetter(from: .init(preFilter: .alwaysDifferent, map: { $0 }))
   }
   
 }

--- a/Sources/VergeRx/VergeStore+Rx.swift
+++ b/Sources/VergeRx/VergeStore+Rx.swift
@@ -1,9 +1,0 @@
-//
-//  VergeStore+Rx.swift
-//  VergeRx
-//
-//  Created by muukii on 2020/01/14.
-//  Copyright © 2020 muukii. All rights reserved.
-//
-
-import Foundation

--- a/Sources/VergeStore/StoreBase.swift
+++ b/Sources/VergeStore/StoreBase.swift
@@ -161,14 +161,12 @@ extension StoreBase {
   }
   
   @available(iOS 13, macOS 10.15, *)
-  public func makeGetter<Output>(
-    filter: @escaping (Value) -> Bool,
-    map: @escaping (Value) -> Output
-  ) -> GetterSource<Value, Output> {
-    
-    _backingStorage.makeGetter(filter: filter, map: map)
-    
+  public func makeGetter<ComparingKey, Output>(
+    from builder: GetterBuilder<State, ComparingKey, Output>
+  ) -> GetterSource<State, Output> {
+    _backingStorage.makeGetter(from: builder)
   }
+   
 }
 
 @available(iOS 13.0, macOS 10.15, *)

--- a/Sources/VergeStore/StoreBase.swift
+++ b/Sources/VergeStore/StoreBase.swift
@@ -161,8 +161,8 @@ extension StoreBase {
   }
   
   @available(iOS 13, macOS 10.15, *)
-  public func makeGetter<ComparingKey, Output>(
-    from builder: GetterBuilder<State, ComparingKey, Output>
+  public func makeGetter<PreComparingKey, Output, PostComparingKey>(
+    from builder: GetterBuilder<State, PreComparingKey, Output, PostComparingKey>
   ) -> GetterSource<State, Output> {
     _backingStorage.makeGetter(from: builder)
   }

--- a/Tests/VergeCoreTests/FilterTests.swift
+++ b/Tests/VergeCoreTests/FilterTests.swift
@@ -16,7 +16,7 @@ final class FilterTests: XCTestCase {
   
   func testHistorical() {
     
-    let filter = HistoricalComparer<Int>.init(selector: { $0 }, comparer: AnyComparerFragment { $0 == $1 })
+    let filter = EqualityComputer<Int>.init(selector: { $0 }, comparer: AnyComparer { $0 == $1 })
         
     XCTAssertEqual(filter.equals(input: 1), false)
     XCTAssertEqual(filter.equals(input: 1), true)
@@ -26,7 +26,7 @@ final class FilterTests: XCTestCase {
   
   func testHistoricalWithFunction() {
     
-    let filter = HistoricalComparer<Int>.init(selector: { $0 }, comparer: AnyComparerFragment { $0 == $1 }).asFunction()
+    let filter = EqualityComputer<Int>.init(selector: { $0 }, comparer: AnyComparer { $0 == $1 }).asFunction()
     
     XCTAssertEqual(filter(1), false)
     XCTAssertEqual(filter(1), true)
@@ -36,7 +36,7 @@ final class FilterTests: XCTestCase {
   
   func testHistoricalWithRegisterFirstValue() {
     
-    let filter = HistoricalComparer<Int>.init(selector: { $0 }, comparer: AnyComparerFragment { $0 == $1 })
+    let filter = EqualityComputer<Int>.init(selector: { $0 }, comparer: AnyComparer { $0 == $1 })
     
     filter.registerFirstValue(1)
     
@@ -52,10 +52,10 @@ final class FilterTests: XCTestCase {
       var c = 0
     }
         
-    let fragment = CombinedComparerFragment<Model>.init(or: [
-      AnyComparerFragment<Model>.init { $0.a == 1 && $1.a == 1 }.asFunction(),
-      AnyComparerFragment<Model>.init { $0.b == 1 && $1.b == 1 }.asFunction(),
-      AnyComparerFragment<Model>.init { $0.c == 1 && $1.c == 1 }.asFunction(),
+    let fragment = CombinedComparer<Model>.init(or: [
+      AnyComparer<Model>.init { $0.a == 1 && $1.a == 1 }.asFunction(),
+      AnyComparer<Model>.init { $0.b == 1 && $1.b == 1 }.asFunction(),
+      AnyComparer<Model>.init { $0.c == 1 && $1.c == 1 }.asFunction(),
     ])
         
     do {
@@ -90,10 +90,10 @@ final class FilterTests: XCTestCase {
       var c = 0
     }
     
-    let fragment = CombinedComparerFragment<Model>.init(and: [
-      AnyComparerFragment<Model>.init { $0.a == 1 && $1.a == 1 }.asFunction(),
-      AnyComparerFragment<Model>.init { $0.b == 1 && $1.b == 1 }.asFunction(),
-      AnyComparerFragment<Model>.init { $0.c == 1 && $1.c == 1 }.asFunction(),
+    let fragment = CombinedComparer<Model>.init(and: [
+      AnyComparer<Model>.init { $0.a == 1 && $1.a == 1 }.asFunction(),
+      AnyComparer<Model>.init { $0.b == 1 && $1.b == 1 }.asFunction(),
+      AnyComparer<Model>.init { $0.c == 1 && $1.c == 1 }.asFunction(),
     ])
     
     do {

--- a/Tests/VergeCoreTests/FilterTests.swift
+++ b/Tests/VergeCoreTests/FilterTests.swift
@@ -16,31 +16,121 @@ final class FilterTests: XCTestCase {
   
   func testHistorical() {
     
-    let filter = Filters.Historical<Int>.init()
+    let filter = HistoricalComparer<Int>.init(selector: { $0 }, comparer: AnyComparerFragment { $0 == $1 })
         
-    XCTAssertEqual(filter.check(input: 1), true)
-    XCTAssertEqual(filter.check(input: 1), false)
-    XCTAssertEqual(filter.check(input: 2), true)
+    XCTAssertEqual(filter.equals(input: 1), false)
+    XCTAssertEqual(filter.equals(input: 1), true)
+    XCTAssertEqual(filter.equals(input: 2), false)
     
   }
   
   func testHistoricalWithFunction() {
     
-    let filter = Filters.Historical<Int>.init().asFunction()
+    let filter = HistoricalComparer<Int>.init(selector: { $0 }, comparer: AnyComparerFragment { $0 == $1 }).asFunction()
     
-    XCTAssertEqual(filter(1), true)
     XCTAssertEqual(filter(1), false)
-    XCTAssertEqual(filter(2), true)
+    XCTAssertEqual(filter(1), true)
+    XCTAssertEqual(filter(2), false)
     
   }
   
   func testHistoricalWithRegisterFirstValue() {
     
-    let filter = Filters.Historical<Int>.init()
+    let filter = HistoricalComparer<Int>.init(selector: { $0 }, comparer: AnyComparerFragment { $0 == $1 })
     
     filter.registerFirstValue(1)
     
-    XCTAssertEqual(filter.check(input: 1), false)
+    XCTAssertEqual(filter.equals(input: 1), true)
+    
+  }
+  
+  func testCombinedFilterOR() {
+    
+    struct Model {
+      var a = 0
+      var b = 0
+      var c = 0
+    }
+        
+    let fragment = CombinedComparerFragment<Model>.init(or: [
+      AnyComparerFragment<Model>.init { $0.a == 1 && $1.a == 1 }.asFunction(),
+      AnyComparerFragment<Model>.init { $0.b == 1 && $1.b == 1 }.asFunction(),
+      AnyComparerFragment<Model>.init { $0.c == 1 && $1.c == 1 }.asFunction(),
+    ])
+        
+    do {
+      let pre = Model()
+      let new = Model()
+      XCTAssertEqual(fragment.equals(previousValue: pre, newValue: new), false)
+    }
+    
+    do {
+      var pre = Model()
+      pre.a = 1
+      var new = Model()
+      new.a = 1
+      XCTAssertEqual(fragment.equals(previousValue: pre, newValue: new), true)
+    }
+    
+    do {
+      var pre = Model()
+      pre.c = 1
+      var new = Model()
+      new.c = 1
+      XCTAssertEqual(fragment.equals(previousValue: pre, newValue: new), true)
+    }
+    
+  }
+  
+  func testCombinedFilterAnd() {
+    
+    struct Model {
+      var a = 0
+      var b = 0
+      var c = 0
+    }
+    
+    let fragment = CombinedComparerFragment<Model>.init(and: [
+      AnyComparerFragment<Model>.init { $0.a == 1 && $1.a == 1 }.asFunction(),
+      AnyComparerFragment<Model>.init { $0.b == 1 && $1.b == 1 }.asFunction(),
+      AnyComparerFragment<Model>.init { $0.c == 1 && $1.c == 1 }.asFunction(),
+    ])
+    
+    do {
+      let pre = Model()
+      let new = Model()
+      XCTAssertEqual(fragment.equals(previousValue: pre, newValue: new), false)
+    }
+    
+    do {
+      var pre = Model()
+      pre.a = 1
+      var new = Model()
+      new.a = 1
+      XCTAssertEqual(fragment.equals(previousValue: pre, newValue: new), false)
+    }
+    
+    do {
+      var pre = Model()
+      pre.a = 1
+      pre.b = 1
+      var new = Model()
+      new.a = 1
+      new.b = 1
+      XCTAssertEqual(fragment.equals(previousValue: pre, newValue: new), false)
+    }
+    
+    do {
+      var pre = Model()
+      pre.a = 1
+      pre.b = 1
+      pre.c = 1
+      var new = Model()
+      new.a = 1
+      new.b = 1
+      new.c = 1
+      XCTAssertEqual(fragment.equals(previousValue: pre, newValue: new), true)
+    }
     
   }
 }

--- a/Tests/VergeCoreTests/FilterTests.swift
+++ b/Tests/VergeCoreTests/FilterTests.swift
@@ -16,7 +16,7 @@ final class FilterTests: XCTestCase {
   
   func testHistorical() {
     
-    let filter = EqualityComputer<Int>.init(selector: { $0 }, comparer: AnyComparer { $0 == $1 })
+    let filter = EqualityComputer<Int>.init(selector: { $0 }, comparer: .init { $0 == $1 })
         
     XCTAssertEqual(filter.equals(input: 1), false)
     XCTAssertEqual(filter.equals(input: 1), true)
@@ -26,7 +26,7 @@ final class FilterTests: XCTestCase {
   
   func testHistoricalWithFunction() {
     
-    let filter = EqualityComputer<Int>.init(selector: { $0 }, comparer: AnyComparer { $0 == $1 }).asFunction()
+    let filter = EqualityComputer<Int>.init(selector: { $0 }, comparer: .init { $0 == $1 }).asFunction()
     
     XCTAssertEqual(filter(1), false)
     XCTAssertEqual(filter(1), true)
@@ -36,7 +36,7 @@ final class FilterTests: XCTestCase {
   
   func testHistoricalWithRegisterFirstValue() {
     
-    let filter = EqualityComputer<Int>.init(selector: { $0 }, comparer: AnyComparer { $0 == $1 })
+    let filter = EqualityComputer<Int>.init(selector: { $0 }, comparer: .init { $0 == $1 })
     
     filter.registerFirstValue(1)
     
@@ -52,10 +52,10 @@ final class FilterTests: XCTestCase {
       var c = 0
     }
         
-    let fragment = CombinedComparer<Model>.init(or: [
-      AnyComparer<Model>.init { $0.a == 1 && $1.a == 1 }.asFunction(),
-      AnyComparer<Model>.init { $0.b == 1 && $1.b == 1 }.asFunction(),
-      AnyComparer<Model>.init { $0.c == 1 && $1.c == 1 }.asFunction(),
+    let fragment = Comparer<Model>.init(or: [
+      Comparer<Model>.init { $0.a == 1 && $1.a == 1 },
+      Comparer<Model>.init { $0.b == 1 && $1.b == 1 },
+      Comparer<Model>.init { $0.c == 1 && $1.c == 1 },
     ])
         
     do {
@@ -90,10 +90,10 @@ final class FilterTests: XCTestCase {
       var c = 0
     }
     
-    let fragment = CombinedComparer<Model>.init(and: [
-      AnyComparer<Model>.init { $0.a == 1 && $1.a == 1 }.asFunction(),
-      AnyComparer<Model>.init { $0.b == 1 && $1.b == 1 }.asFunction(),
-      AnyComparer<Model>.init { $0.c == 1 && $1.c == 1 }.asFunction(),
+    let fragment = Comparer<Model>.init(and: [
+      Comparer<Model>.init { $0.a == 1 && $1.a == 1 },
+      Comparer<Model>.init { $0.b == 1 && $1.b == 1 },
+      Comparer<Model>.init { $0.c == 1 && $1.c == 1 },
     ])
     
     do {

--- a/Tests/VergeCoreTests/GetterTests.swift
+++ b/Tests/VergeCoreTests/GetterTests.swift
@@ -60,9 +60,8 @@ class GetterTests: XCTestCase {
     var updateCount = 0
                          
     let g = storage.makeGetter {
-      $0.preFilter(.noFilter)
-        .map(\.self)
-        .postFilter(keySelector: \.description, comparer: .init(==))
+      $0.preFilter(.init())
+        .map { $0 * 2 }
     }
         
     g.sink { _ in

--- a/Tests/VergeCoreTests/GetterTests.swift
+++ b/Tests/VergeCoreTests/GetterTests.swift
@@ -24,8 +24,13 @@ class GetterTests: XCTestCase {
     
     var updateCount = 0
     
-    let g = storage.makeGetter(filter: Filters.Historical.init().asFunction(), map: { $0 * 2 })
-    
+    let g = storage.makeGetter(from: .init(
+      equalityComparerBuilder: .init(
+        selector: { $0 },
+        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      map: { $0 * 2})
+    )
+        
     g.sink { _ in
       updateCount += 1
     }
@@ -56,7 +61,12 @@ class GetterTests: XCTestCase {
     
     var updateCount = 0
     
-    let g = storage.makeGetter(filter: Filters.Historical.init().asFunction(), map: { $0 * 2 })
+    let g = storage.makeGetter(from: .init(
+      equalityComparerBuilder: .init(
+        selector: { $0 },
+        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      map: { $0 * 2 })
+    )
     
     g.sink { _ in
       updateCount += 1
@@ -77,6 +87,10 @@ class GetterTests: XCTestCase {
       $0 = 2
     }
     
+    storage.update {
+      $0 = 2
+    }
+    
     XCTAssertEqual(updateCount, 2)
     
   }
@@ -85,7 +99,12 @@ class GetterTests: XCTestCase {
     
     let storage = Storage<Int>(1)
     
-    var first: GetterSource<Int, Int>! = storage.makeGetter(filter: Filters.Historical.init().asFunction(), map: { $0 })
+    var first: GetterSource<Int, Int>! = storage.makeGetter(from: .init(
+      equalityComparerBuilder: .init(
+        selector: { $0 },
+        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      map: { $0 })
+    )
     
     weak var weakFirst = first
     
@@ -124,7 +143,12 @@ class GetterTests: XCTestCase {
     
     let storage = Storage<Int>(1)
     
-    let first = storage.makeGetter(filter: Filters.Historical.init().asFunction(), map: { $0 })
+    let first = storage.makeGetter(from: .init(
+      equalityComparerBuilder: .init(
+        selector: { $0 },
+        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      map: { $0 })
+    )
     
     let share1 = Getter {
       first.map { $0 }
@@ -150,8 +174,19 @@ class GetterTests: XCTestCase {
     
     let storage = Storage<Int>(1)
     
-    let first = storage.makeGetter(filter: Filters.Historical.init().asFunction(), map: { $0 })
-    let second = storage.makeGetter(filter: Filters.Historical.init().asFunction(), map: { -$0 })
+    let first = storage.makeGetter(from: .init(
+      equalityComparerBuilder: .init(
+        selector: { $0 },
+        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      map: { $0 })
+    )
+    
+    let second = storage.makeGetter(from: .init(
+      equalityComparerBuilder: .init(
+        selector: { $0 },
+        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      map: { -$0 })
+    )
     
     let combined = Getter {
       first.combineLatest(second)

--- a/Tests/VergeCoreTests/GetterTests.swift
+++ b/Tests/VergeCoreTests/GetterTests.swift
@@ -25,9 +25,7 @@ class GetterTests: XCTestCase {
     var updateCount = 0
     
     let g = storage.makeGetter(from: .init(
-      equalityComparerBuilder: .init(
-        selector: { $0 },
-        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      preFilter: .make(),
       map: { $0 * 2})
     )
         
@@ -62,9 +60,7 @@ class GetterTests: XCTestCase {
     var updateCount = 0
     
     let g = storage.makeGetter(from: .init(
-      equalityComparerBuilder: .init(
-        selector: { $0 },
-        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      preFilter: .make(),
       map: { $0 * 2 })
     )
     
@@ -100,9 +96,7 @@ class GetterTests: XCTestCase {
     let storage = Storage<Int>(1)
     
     var first: GetterSource<Int, Int>! = storage.makeGetter(from: .init(
-      equalityComparerBuilder: .init(
-        selector: { $0 },
-        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      preFilter: .make(),
       map: { $0 })
     )
     
@@ -143,12 +137,7 @@ class GetterTests: XCTestCase {
     
     let storage = Storage<Int>(1)
     
-    let first = storage.makeGetter(from: .init(
-      equalityComparerBuilder: .init(
-        selector: { $0 },
-        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
-      map: { $0 })
-    )
+    let first = storage.makeGetter(from: .make(map: { $0 }))
     
     let share1 = Getter {
       first.map { $0 }
@@ -175,16 +164,16 @@ class GetterTests: XCTestCase {
     let storage = Storage<Int>(1)
     
     let first = storage.makeGetter(from: .init(
-      equalityComparerBuilder: .init(
-        selector: { $0 },
-        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      preFilter: .init(
+        keySelector: { $0 },
+        comparer: AnyComparer.init { $0 == $1 }.asFunction()),
       map: { $0 })
     )
     
     let second = storage.makeGetter(from: .init(
-      equalityComparerBuilder: .init(
-        selector: { $0 },
-        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      preFilter: .init(
+        keySelector: { $0 },
+        comparer: AnyComparer.init { $0 == $1 }.asFunction()),
       map: { -$0 })
     )
     

--- a/Tests/VergeORMTests/PerformanceTests.swift
+++ b/Tests/VergeORMTests/PerformanceTests.swift
@@ -188,8 +188,8 @@ class PerformanceTests: XCTestCase {
   
   func testInsertManyEachTransaction() {
     measure {
-      
-      for i in 0..<1000 {
+      /// O(n^2)
+      for i in 0..<10 {
         state.db.performBatchUpdates { (context) in
           let author = Author(rawID: "author.\(i)")
           context.author.insert(author)

--- a/Tests/VergeRxTests/MemoizeGetterTests.swift
+++ b/Tests/VergeRxTests/MemoizeGetterTests.swift
@@ -53,9 +53,9 @@ class MemoizeGetterTests: XCTestCase {
     var callCount = 0
                                  
     let getter = store.rx.makeGetter(from: .init(
-      equalityComparerBuilder: .init(
-        selector: { $0.count },
-        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      preFilter: .init(
+        keySelector: { $0.count },
+        comparer: AnyComparer.init { $0 == $1 }.asFunction()),
       map: { state -> Int in
         callCount += 1
         return state.count * 2

--- a/Tests/VergeRxTests/MemoizeGetterTests.swift
+++ b/Tests/VergeRxTests/MemoizeGetterTests.swift
@@ -52,11 +52,12 @@ class MemoizeGetterTests: XCTestCase {
     
     var callCount = 0
                                  
-    let getter = store.rx.makeGetter(from: .init(
+    let getter = store.rx.makeGetter(from: .make(
       preFilter: .init(
         keySelector: { $0.count },
-        comparer: AnyComparer.init { $0 == $1 }.asFunction()),
-      map: { state -> Int in
+        comparer: .init { $0 == $1 }
+      ),
+      transform: { state -> Int in
         callCount += 1
         return state.count * 2
     })

--- a/Tests/VergeRxTests/MemoizeGetterTests.swift
+++ b/Tests/VergeRxTests/MemoizeGetterTests.swift
@@ -51,13 +51,16 @@ class MemoizeGetterTests: XCTestCase {
     let dispatcher = RootDispatcher(target: store)
     
     var callCount = 0
-                    
-    let getter = store.rx.makeGetter(
-      filter: Filters.Historical.init(selector: { $0.count }, predicate: !=).asFunction(),
-      map: { (state) -> Int in
+                                 
+    let getter = store.rx.makeGetter(from: .init(
+      equalityComparerBuilder: .init(
+        selector: { $0.count },
+        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      map: { state -> Int in
         callCount += 1
         return state.count * 2
     })
+    )
         
     XCTAssertEqual(getter.value, 0)
     

--- a/Tests/VergeRxTests/VergeGetterRxTests.swift
+++ b/Tests/VergeRxTests/VergeGetterRxTests.swift
@@ -35,14 +35,12 @@ class VergeGetterRxTests: XCTestCase {
     let storage = Storage<Int>(1)
     
     var updateCount = 0
+            
+    let g = storage.rx.makeGetter {
+      $0.preFilter(comparer: .init(==))
+        .map { $0 * 2 }
+    }
         
-    let g = storage.rx.makeGetter(from: .init(
-      preFilter: .init(
-        keySelector: { $0 },
-        comparer: AnyComparer.init { $0 == $1 }.asFunction()),
-      map: { $0 * 2})
-    )
-    
     _ = g.subscribe(onNext: { _ in
       updateCount += 1
     })
@@ -76,13 +74,11 @@ class VergeGetterRxTests: XCTestCase {
   func testChain() {
     
     let storage = Storage<Int>(1)
-            
-    var first: RxGetterSource<Int, Int>! = storage.rx.makeGetter(from: .init(
-      preFilter: .init(
-        keySelector: { $0 },
-        comparer: AnyComparer.init { $0 == $1 }.asFunction()),
-      map: { $0 })
-    )
+                 
+    var first: RxGetterSource<Int, Int>! = storage.rx.makeGetter {
+      $0.preFilter(comparer: .init(==))
+        .map { $0 * 2 }
+    }
     
     weak var weakFirst = first
                 
@@ -113,14 +109,12 @@ class VergeGetterRxTests: XCTestCase {
   func testShare() {
     
     let storage = Storage<Int>(1)
+            
+    let first: RxGetterSource<Int, Int>! = storage.rx.makeGetter {
+      $0.preFilter(comparer: .init(==))
+        .map { $0 * 2 }
+    }
     
-    let first = storage.rx.makeGetter(from: .init(
-      preFilter: .init(
-        keySelector: { $0 },
-        comparer: AnyComparer.init { $0 == $1 }.asFunction()),
-      map: { $0 })
-    )
-        
     let share1 = RxGetter {
       first.map { $0 }
     }
@@ -145,20 +139,16 @@ class VergeGetterRxTests: XCTestCase {
     
     let storage = Storage<Int>(1)
     
-    let first = storage.rx.makeGetter(from: .init(
-      preFilter: .init(
-        keySelector: { $0 },
-        comparer: AnyComparer.init { $0 == $1 }.asFunction()),
-      map: { $0 })
-    )
-    
-    let second = storage.rx.makeGetter(from: .init(
-      preFilter: .init(
-        keySelector: { $0 },
-        comparer: AnyComparer.init { $0 == $1 }.asFunction()),
-      map: { -$0 })
-    )
+    let first = storage.rx.makeGetter {
+      $0.preFilter(comparer: .init(==))
+        .map(\.self)
+    }
         
+    let second = storage.rx.makeGetter {
+      $0.preFilter(comparer: .init(==))
+        .map { -$0 }
+    }
+            
     let combined = RxGetter {
       Observable.combineLatest(first, second)
         .map { $0 + $1 }

--- a/Tests/VergeRxTests/VergeGetterRxTests.swift
+++ b/Tests/VergeRxTests/VergeGetterRxTests.swift
@@ -77,7 +77,7 @@ class VergeGetterRxTests: XCTestCase {
                  
     var first: RxGetterSource<Int, Int>! = storage.rx.makeGetter {
       $0.preFilter(comparer: .init(==))
-        .map { $0 * 2 }
+        .map { $0 }
     }
     
     weak var weakFirst = first
@@ -112,7 +112,7 @@ class VergeGetterRxTests: XCTestCase {
             
     let first: RxGetterSource<Int, Int>! = storage.rx.makeGetter {
       $0.preFilter(comparer: .init(==))
-        .map { $0 * 2 }
+        .map { $0 }
     }
     
     let share1 = RxGetter {

--- a/Tests/VergeRxTests/VergeGetterRxTests.swift
+++ b/Tests/VergeRxTests/VergeGetterRxTests.swift
@@ -35,8 +35,13 @@ class VergeGetterRxTests: XCTestCase {
     let storage = Storage<Int>(1)
     
     var updateCount = 0
-    
-    let g = storage.rx.makeGetter(filter: Filters.Historical.init().asFunction(), map: { $0 * 2})
+        
+    let g = storage.rx.makeGetter(from: .init(
+      equalityComparerBuilder: .init(
+        selector: { $0 },
+        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      map: { $0 * 2})
+    )
     
     _ = g.subscribe(onNext: { _ in
       updateCount += 1
@@ -71,8 +76,13 @@ class VergeGetterRxTests: XCTestCase {
   func testChain() {
     
     let storage = Storage<Int>(1)
-        
-    var first: RxGetterSource<Int, Int>! = storage.rx.makeGetter(filter: Filters.Historical.init().asFunction(), map: { $0 })
+            
+    var first: RxGetterSource<Int, Int>! = storage.rx.makeGetter(from: .init(
+      equalityComparerBuilder: .init(
+        selector: { $0 },
+        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      map: { $0 })
+    )
     
     weak var weakFirst = first
                 
@@ -104,7 +114,12 @@ class VergeGetterRxTests: XCTestCase {
     
     let storage = Storage<Int>(1)
     
-    let first = storage.rx.makeGetter(filter: Filters.Historical.init().asFunction(), map: { $0 })
+    let first = storage.rx.makeGetter(from: .init(
+      equalityComparerBuilder: .init(
+        selector: { $0 },
+        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      map: { $0 })
+    )
         
     let share1 = RxGetter {
       first.map { $0 }
@@ -130,9 +145,20 @@ class VergeGetterRxTests: XCTestCase {
     
     let storage = Storage<Int>(1)
     
-    let first = storage.rx.makeGetter(filter: Filters.Historical.init().asFunction(), map: { $0 })
-    let second = storage.rx.makeGetter(filter: Filters.Historical.init().asFunction(), map: { -$0 })
+    let first = storage.rx.makeGetter(from: .init(
+      equalityComparerBuilder: .init(
+        selector: { $0 },
+        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      map: { $0 })
+    )
     
+    let second = storage.rx.makeGetter(from: .init(
+      equalityComparerBuilder: .init(
+        selector: { $0 },
+        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      map: { -$0 })
+    )
+        
     let combined = RxGetter {
       Observable.combineLatest(first, second)
         .map { $0 + $1 }

--- a/Tests/VergeRxTests/VergeGetterRxTests.swift
+++ b/Tests/VergeRxTests/VergeGetterRxTests.swift
@@ -37,9 +37,9 @@ class VergeGetterRxTests: XCTestCase {
     var updateCount = 0
         
     let g = storage.rx.makeGetter(from: .init(
-      equalityComparerBuilder: .init(
-        selector: { $0 },
-        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      preFilter: .init(
+        keySelector: { $0 },
+        comparer: AnyComparer.init { $0 == $1 }.asFunction()),
       map: { $0 * 2})
     )
     
@@ -78,9 +78,9 @@ class VergeGetterRxTests: XCTestCase {
     let storage = Storage<Int>(1)
             
     var first: RxGetterSource<Int, Int>! = storage.rx.makeGetter(from: .init(
-      equalityComparerBuilder: .init(
-        selector: { $0 },
-        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      preFilter: .init(
+        keySelector: { $0 },
+        comparer: AnyComparer.init { $0 == $1 }.asFunction()),
       map: { $0 })
     )
     
@@ -115,9 +115,9 @@ class VergeGetterRxTests: XCTestCase {
     let storage = Storage<Int>(1)
     
     let first = storage.rx.makeGetter(from: .init(
-      equalityComparerBuilder: .init(
-        selector: { $0 },
-        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      preFilter: .init(
+        keySelector: { $0 },
+        comparer: AnyComparer.init { $0 == $1 }.asFunction()),
       map: { $0 })
     )
         
@@ -146,16 +146,16 @@ class VergeGetterRxTests: XCTestCase {
     let storage = Storage<Int>(1)
     
     let first = storage.rx.makeGetter(from: .init(
-      equalityComparerBuilder: .init(
-        selector: { $0 },
-        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      preFilter: .init(
+        keySelector: { $0 },
+        comparer: AnyComparer.init { $0 == $1 }.asFunction()),
       map: { $0 })
     )
     
     let second = storage.rx.makeGetter(from: .init(
-      equalityComparerBuilder: .init(
-        selector: { $0 },
-        predicate: AnyComparerFragment.init { $0 == $1 }.asFunction()),
+      preFilter: .init(
+        keySelector: { $0 },
+        comparer: AnyComparer.init { $0 == $1 }.asFunction()),
       map: { -$0 })
     )
         

--- a/Tests/VergeStoreTests/MostSimpleSampleTests.swift
+++ b/Tests/VergeStoreTests/MostSimpleSampleTests.swift
@@ -59,7 +59,7 @@ enum Sample {
     let count = store.state.count
     
     // Subscribe state
-    store.makeGetter()
+    store.makeGetter(preFilter: .noFilter)
       .sink { state in
         
     }

--- a/Tests/VergeStoreTests/VergeStoreTests.swift
+++ b/Tests/VergeStoreTests/VergeStoreTests.swift
@@ -227,7 +227,7 @@ final class VergeStoreTests: XCTestCase {
     
     let expectation = XCTestExpectation()
             
-    let getter = store.makeGetter()
+    let getter = store.makeGetter(preFilter: .noFilter)
     getter
       .dropFirst()
       .sink { (state) in

--- a/Verge.xcodeproj/project.pbxproj
+++ b/Verge.xcodeproj/project.pbxproj
@@ -133,7 +133,6 @@
 		4BDBDF6B23CE02CF00EEA112 /* VergeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF2BCE1238A85A700F70CDA /* VergeViewModelTests.swift */; };
 		4BDBDF6C23CE02CF00EEA112 /* StandaloneVergeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B63829C23980D4600FAD87F /* StandaloneVergeViewModelTests.swift */; };
 		4BDBDF6D23CE02CF00EEA112 /* ChainingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE76218239AA4A1009EB209 /* ChainingViewModelTests.swift */; };
-		4BDBDF6F23CE067800EEA112 /* VergeStore+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BDBDF6E23CE067800EEA112 /* VergeStore+Rx.swift */; };
 		4BDBDF7723CE0C4200EEA112 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BDBDF7623CE0C4200EEA112 /* AppDelegate.swift */; };
 		4BDBDF7B23CE0C4200EEA112 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BDBDF7A23CE0C4200EEA112 /* ViewController.swift */; };
 		4BDBDF7E23CE0C4200EEA112 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4BDBDF7C23CE0C4200EEA112 /* Main.storyboard */; };
@@ -509,7 +508,6 @@
 		4BD379EC23BD94D800CE474C /* AnyEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEntity.swift; sourceTree = "<group>"; };
 		4BD6850423C82E6C00D8A620 /* ORMGetterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ORMGetterTests.swift; sourceTree = "<group>"; };
 		4BD85F2C2331213800FD04E9 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS13.0.sdk/System/Library/Frameworks/SwiftUI.framework; sourceTree = DEVELOPER_DIR; };
-		4BDBDF6E23CE067800EEA112 /* VergeStore+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VergeStore+Rx.swift"; sourceTree = "<group>"; };
 		4BDBDF7423CE0C4200EEA112 /* VergeStoreDemoUIKit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VergeStoreDemoUIKit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4BDBDF7623CE0C4200EEA112 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		4BDBDF7A23CE0C4200EEA112 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -708,7 +706,6 @@
 			children = (
 				4BAC16C023C806F100BF49D9 /* ORM */,
 				4BFC3A0E23C758FD00801CB4 /* RxGetter.swift */,
-				4BDBDF6E23CE067800EEA112 /* VergeStore+Rx.swift */,
 				4B7F385123895B24000B9ACF /* VergeStore+Storage+Rx.swift */,
 				4BA5914E23DF5146007F614C /* FunctionBuilders.swift */,
 				4B17439123C766D70074C457 /* VergeRx.h */,
@@ -1733,7 +1730,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4BDBDF6F23CE067800EEA112 /* VergeStore+Rx.swift in Sources */,
 				4B1743A123C7671C0074C457 /* VergeStore+Storage+Rx.swift in Sources */,
 				4BAC16BF23C806E000BF49D9 /* EntityType+.swift in Sources */,
 				4BA5914F23DF5146007F614C /* FunctionBuilders.swift in Sources */,

--- a/Verge.xcodeproj/project.pbxproj
+++ b/Verge.xcodeproj/project.pbxproj
@@ -70,7 +70,7 @@
 		4B86A4A11F969C7D002D54FE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4B86A4A01F969C7D002D54FE /* Assets.xcassets */; };
 		4B86A4A41F969C7D002D54FE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4B86A4A21F969C7D002D54FE /* LaunchScreen.storyboard */; };
 		4B89538523CCE3B1002F95C8 /* FilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B89538423CCE3B1002F95C8 /* FilterTests.swift */; };
-		4B8EB4F923C034A900035B2A /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B8EB4F823C034A900035B2A /* Filter.swift */; };
+		4B8EB4F923C034A900035B2A /* Comparers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B8EB4F823C034A900035B2A /* Comparers.swift */; };
 		4B94913C239C25C600370067 /* VergeStore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B786320233912AB009B9C1B /* VergeStore.framework */; };
 		4B94913D239C25C600370067 /* VergeStore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4B786320233912AB009B9C1B /* VergeStore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4B949141239C25CA00370067 /* VergeORM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B475BB2239AB954008A03E1 /* VergeORM.framework */; };
@@ -93,6 +93,7 @@
 		4BA3E1A523C359F40095629B /* Signpost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BA3E1A423C359F40095629B /* Signpost.swift */; };
 		4BA5914F23DF5146007F614C /* FunctionBuilders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BA5914E23DF5146007F614C /* FunctionBuilders.swift */; };
 		4BA5915123DF536F007F614C /* FunctionBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BA5915023DF536F007F614C /* FunctionBuilderTests.swift */; };
+		4BA8DB3623E36465001CDADA /* EqualityComputer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BA8DB3523E36465001CDADA /* EqualityComputer.swift */; };
 		4BAC16BF23C806E000BF49D9 /* EntityType+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BAC16BE23C806E000BF49D9 /* EntityType+.swift */; };
 		4BAC16C223C8072300BF49D9 /* EntityGetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BAC16C123C8072300BF49D9 /* EntityGetter.swift */; };
 		4BAD4FDD1FC80B0100C841FA /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BAD4FDC1FC80B0100C841FA /* Logger.swift */; };
@@ -453,7 +454,7 @@
 		4B86A4A31F969C7D002D54FE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		4B86A4A51F969C7D002D54FE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4B89538423CCE3B1002F95C8 /* FilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTests.swift; sourceTree = "<group>"; };
-		4B8EB4F823C034A900035B2A /* Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
+		4B8EB4F823C034A900035B2A /* Comparers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comparers.swift; sourceTree = "<group>"; };
 		4B93EC7323307637002BB30B /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		4B949128239C257500370067 /* VergeStoreDemoSwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VergeStoreDemoSwiftUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B949146239C264D00370067 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -473,6 +474,7 @@
 		4BA3E1A423C359F40095629B /* Signpost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signpost.swift; sourceTree = "<group>"; };
 		4BA5914E23DF5146007F614C /* FunctionBuilders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionBuilders.swift; sourceTree = "<group>"; };
 		4BA5915023DF536F007F614C /* FunctionBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionBuilderTests.swift; sourceTree = "<group>"; };
+		4BA8DB3523E36465001CDADA /* EqualityComputer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualityComputer.swift; sourceTree = "<group>"; };
 		4BAC16BE23C806E000BF49D9 /* EntityType+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EntityType+.swift"; sourceTree = "<group>"; };
 		4BAC16C123C8072300BF49D9 /* EntityGetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityGetter.swift; sourceTree = "<group>"; };
 		4BAD4FDC1FC80B0100C841FA /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
@@ -1052,7 +1054,8 @@
 				4BFA229E23A63B56008D7BCB /* VergeCore.h */,
 				4BA3E1A423C359F40095629B /* Signpost.swift */,
 				4BF2BCD9238A7B6900F70CDA /* EventEmitter.swift */,
-				4B8EB4F823C034A900035B2A /* Filter.swift */,
+				4B8EB4F823C034A900035B2A /* Comparers.swift */,
+				4BA8DB3523E36465001CDADA /* EqualityComputer.swift */,
 				4B42740C236F1D2D00C302C8 /* Storage.swift */,
 				4B4011BE23C77CEC00C582BC /* Getter.swift */,
 				4B54516F23CCC7E700770E61 /* GetterBuilder.swift */,
@@ -1915,8 +1918,9 @@
 				4B4DF80023A69CD800D53E9D /* ValueContainerType.swift in Sources */,
 				4B54517023CCC7E700770E61 /* GetterBuilder.swift in Sources */,
 				4BFA22B323A63C38008D7BCB /* EventEmitter.swift in Sources */,
-				4B8EB4F923C034A900035B2A /* Filter.swift in Sources */,
+				4B8EB4F923C034A900035B2A /* Comparers.swift in Sources */,
 				4B4011BF23C77CEC00C582BC /* Getter.swift in Sources */,
+				4BA8DB3623E36465001CDADA /* EqualityComputer.swift in Sources */,
 				4BFA22BC23A642B3008D7BCB /* Storage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
What problem with current syntax.

Getter / RxGetter must get the initial value from the sequence.
Since current syntax can describe the condition that no emits initially.
In the new Syntax, It has been focusing on comparing previous and new values.
With this, since it has no previous value when the sequence started, it emits the initial value absolutely.

Before 

```swift
storage.rx.makeGetter(filter: Filters.Historical.init().asFunction(), map: { $0 * 2 })
```

After 

```swift
storage.rx.makeGetter {
  $0.preFilter(comparer: .init(==))
    .map { $0 * 2 }
}
```