### PR TITLE
Allow the instantation of NoState

### DIFF
--- a/Sources/VergeClassic/Verge.swift
+++ b/Sources/VergeClassic/Verge.swift
@@ -14,7 +14,9 @@ public enum VergeInternalError : Error {
 }
 
 public enum NoActivity {}
-public struct NoState {}
+public struct NoState {
+  public init() {}
+}
 
 public protocol VergeLogging {
 


### PR DESCRIPTION
Until now, since the init was internal, it was not possible to do:

```
let state: Storage<State> = .init(.init())
typealias State = NoState
```

Now it is.