### PR TITLE
Remove KeyPath selector for Swift5.2

### DIFF
--- a/Sources/VergeClassic/Storage+Rx.swift
+++ b/Sources/VergeClassic/Storage+Rx.swift
@@ -39,28 +39,6 @@ extension ReadonlyStorage {
   /// Returns an observable sequence that contains only changed elements according to the `comparer`.
   ///
   /// - Parameters:
-  ///   - selector: KeyPath to property
-  ///   - comparer: 
-  /// - Returns: Returns an observable sequence that contains only changed elements according to the `comparer`.
-  public func changed<S>(_ selector: KeyPath<Value, S>, _ comparer: @escaping (S, S) throws -> Bool) -> Observable<S> {
-    asObservable()
-      .map { $0[keyPath: selector] }
-      .distinctUntilChanged(comparer)
-  }
-  
-  /// Returns an observable sequence that contains only changed elements according to the `comparer`.
-  ///
-  /// - Parameters:
-  ///   - selector: KeyPath to property
-  ///   - comparer:
-  /// - Returns: Returns an observable sequence that contains only changed elements according to the `comparer`.
-  public func changed<S : Equatable>(_ selector: KeyPath<Value, S>) -> Observable<S> {
-    changed(selector, ==)
-  }
-  
-  /// Returns an observable sequence that contains only changed elements according to the `comparer`.
-  ///
-  /// - Parameters:
   ///   - selector:
   ///   - comparer:
   /// - Returns: Returns an observable sequence that contains only changed elements according to the `comparer`.
@@ -79,39 +57,6 @@ extension ReadonlyStorage {
   /// - Returns: Returns an observable sequence that contains only changed elements according to the `comparer`.
   public func changedDriver<S : Equatable>(_ selector: @escaping (Value) -> S) -> Driver<S> {
     changedDriver(selector, ==)
-  }
-  
-  /// Returns an observable sequence as Driver that contains only changed elements according to the `comparer`.
-  ///
-  /// - Parameters:
-  ///   - selector: KeyPath to property
-  ///   - comparer:
-  /// - Returns: Returns an observable sequence as Driver that contains only changed elements according to the `comparer`.
-  public func changedDriver<S>(_ selector: KeyPath<Value, S>, _ comparer: @escaping (S, S) throws -> Bool) -> Driver<S> {
-    asObservable()
-      .map { $0[keyPath: selector] }
-      .distinctUntilChanged(comparer)
-      .asDriver(onErrorRecover: { _ in .empty() })
-  }
-  
-  /// Returns an observable sequence as Driver that contains only changed elements according to the `comparer`.
-  ///
-  /// - Parameters:
-  ///   - selector: KeyPath to property
-  ///   - comparer:
-  /// - Returns: Returns an observable sequence as Driver that contains only changed elements according to the `comparer`.
-  public func changedDriver<S : Equatable>(_ selector: KeyPath<Value, S>) -> Driver<S> {
-    changedDriver(selector, ==)
-  }
-  
-  /// Projects each property of Value into a new form.
-  ///
-  /// - Parameter keyPath:
-  /// - Returns:
-  public func map<U>(_ keyPath: KeyPath<Value, U>) -> ReadonlyStorage<U> {
-    map {
-      $0[keyPath: keyPath]
-    }
   }
   
 }

--- a/Sources/VergeRx/VergeStore+Storage+Rx.swift
+++ b/Sources/VergeRx/VergeStore+Storage+Rx.swift
@@ -51,29 +51,6 @@ extension ObservableType where Element : StateType {
   /// Returns an observable sequence that contains only changed elements according to the `comparer`.
   ///
   /// - Parameters:
-  ///   - selector: KeyPath to property
-  ///   - comparer:
-  /// - Returns: Returns an observable sequence that contains only changed elements according to the `comparer`.
-  public func changed<S>(_ selector: KeyPath<Element, S>, _ comparer: @escaping (S, S) throws -> Bool) -> Observable<S> {
-    return
-      asObservable()
-        .map { $0[keyPath: selector] }
-        .distinctUntilChanged(comparer)
-  }
-      
-  /// Returns an observable sequence that contains only changed elements according to the `comparer`.
-  ///
-  /// - Parameters:
-  ///   - selector: KeyPath to property
-  ///   - comparer:
-  /// - Returns: Returns an observable sequence that contains only changed elements according to the `comparer`.
-  public func changed<S : Equatable>(_ selector: KeyPath<Element, S>) -> Observable<S> {
-    return changed(selector, ==)
-  }
-    
-  /// Returns an observable sequence that contains only changed elements according to the `comparer`.
-  ///
-  /// - Parameters:
   ///   - selector:
   ///   - comparer:
   /// - Returns: Returns an observable sequence that contains only changed elements according to the `comparer`.
@@ -92,30 +69,6 @@ extension ObservableType where Element : StateType {
   ///   - comparer:
   /// - Returns: Returns an observable sequence that contains only changed elements according to the `comparer`.
   public func changedDriver<S : Equatable>(_ selector: @escaping (Element) -> S) -> Driver<S> {
-    return changedDriver(selector, ==)
-  }
-  
-  /// Returns an observable sequence as Driver that contains only changed elements according to the `comparer`.
-  ///
-  /// - Parameters:
-  ///   - selector: KeyPath to property
-  ///   - comparer:
-  /// - Returns: Returns an observable sequence as Driver that contains only changed elements according to the `comparer`.
-  public func changedDriver<S>(_ selector: KeyPath<Element, S>, _ comparer: @escaping (S, S) throws -> Bool) -> Driver<S> {
-    return
-      asObservable()
-        .map { $0[keyPath: selector] }
-        .distinctUntilChanged(comparer)
-        .asDriver(onErrorRecover: { _ in .empty() })
-  }
-  
-  /// Returns an observable sequence as Driver that contains only changed elements according to the `comparer`.
-  ///
-  /// - Parameters:
-  ///   - selector: KeyPath to property
-  ///   - comparer:
-  /// - Returns: Returns an observable sequence as Driver that contains only changed elements according to the `comparer`.
-  public func changedDriver<S : Equatable>(_ selector: KeyPath<Element, S>) -> Driver<S> {
     return changedDriver(selector, ==)
   }
   


### PR DESCRIPTION
In Swift5.2 we can create closure from KeyPath.
So we don't need to use KeyPath based selector anymore.