### PR TITLE
To avoid dangling pointer or memory leaks

### DIFF
--- a/All.xctestplan
+++ b/All.xctestplan
@@ -30,6 +30,9 @@
       }
     },
     {
+      "skippedTests" : [
+        "ReproduceDeadlockTests\/testReproduceDeadlock()"
+      ],
       "target" : {
         "containerPath" : "container:Verge.xcodeproj",
         "identifier" : "4B1743A623C767670074C457",

--- a/Sources/VergeClassic/Verge.swift
+++ b/Sources/VergeClassic/Verge.swift
@@ -281,7 +281,7 @@ public final class DispatchingContext<Verge : VergeType> {
     function: StaticString = #function,
     line: UInt = #line
   ) {
-    source.emit(activity, file: file, function: function, line: line)
+    source.send(activity, file: file, function: function, line: line)
   }
    
   @available(*, deprecated, renamed: "send")
@@ -291,7 +291,7 @@ public final class DispatchingContext<Verge : VergeType> {
     function: StaticString = #function,
     line: UInt = #line
     ) {
-    source.emit(activity, file: file, function: function, line: line)
+    source.send(activity, file: file, function: function, line: line)
   }
 
 }

--- a/Sources/VergeCore/EventEmitter.swift
+++ b/Sources/VergeCore/EventEmitter.swift
@@ -114,7 +114,7 @@ public final class EventEmitter<Event>: EventEmitterType {
   
   private var __publisher: Any?
   
-  private let lock = VergeConcurrency.UnfairLock()
+  private let lock = NSRecursiveLock()
   
   private var subscribers: [EventEmitterCancellable : (Event) -> Void] = [:]
   

--- a/Sources/VergeCore/Storage.swift
+++ b/Sources/VergeCore/Storage.swift
@@ -41,7 +41,7 @@ open class ReadonlyStorage<Value>: CustomReflectable {
   
   fileprivate var nonatomicValue: Value
   
-  private let _lock = NSLock()
+  private let _lock = NSRecursiveLock()
   
   fileprivate let upstreams: [AnyObject]
   

--- a/Sources/VergeCore/SynchronizationTracker.swift
+++ b/Sources/VergeCore/SynchronizationTracker.swift
@@ -1,0 +1,49 @@
+//
+//  SynchronizationTracker.swift
+//  VergeCore
+//
+//  Created by muukii on 2020/04/21.
+//  Copyright © 2020 muukii. All rights reserved.
+//
+
+import Foundation
+
+extension VergeConcurrency {
+  /// imported RxSwift
+  public final class SynchronizationTracker {
+    private let _lock = NSRecursiveLock()
+    
+    private var _threads = [UnsafeMutableRawPointer: Int]()
+    
+    private func synchronizationError(_ message: String) {
+      print(message)
+    }
+    
+    public init() {}
+    
+    public func register() {
+      self._lock.lock(); defer { self._lock.unlock() }
+      let pointer = Unmanaged.passUnretained(Thread.current).toOpaque()
+      let count = (self._threads[pointer] ?? 0) + 1
+      
+      if count > 1 {
+        self.synchronizationError("Reentrancy anomaly was detected")
+      }
+      
+      self._threads[pointer] = count
+      
+      if self._threads.count > 1 {
+        self.synchronizationError("Synchronization anomaly was detected")
+      }
+    }
+    
+    public func unregister() {
+      self._lock.lock(); defer { self._lock.unlock() }
+      let pointer = Unmanaged.passUnretained(Thread.current).toOpaque()
+      self._threads[pointer] = (self._threads[pointer] ?? 1) - 1
+      if self._threads[pointer] == 0 {
+        self._threads[pointer] = nil
+      }
+    }
+  }
+}

--- a/Tests/VergeORMTests/ORMGetterTests.swift
+++ b/Tests/VergeORMTests/ORMGetterTests.swift
@@ -184,7 +184,7 @@ class ORMGetterTests: XCTestCase {
     
     XCTContext.runActivity(named: "updateName") { _ in
       
-      storage.commit { state in
+      _ = storage.commit { state in
         state.db.performBatchUpdates { (context) in
           context.author.updateIfExists(id: .init("muukii")) { (author) in
             author.name = "Hiroshi"
@@ -200,7 +200,7 @@ class ORMGetterTests: XCTestCase {
     
     XCTContext.runActivity(named: "updateName, but not changed") { _ in
       
-      storage.commit { state in
+      _ = storage.commit { state in
         state.db.performBatchUpdates { (context) in
           context.author.updateIfExists(id: .init("muukii")) { (author) in
             author.name = "Hiroshi"
@@ -228,7 +228,7 @@ class ORMGetterTests: XCTestCase {
     
     XCTContext.runActivity(named: "Adding book, getter would not emit changes") { _ -> Void in
       
-      storage.commit { state in
+      _ = storage.commit { state in
         state.db.performBatchUpdates { (context) in
           context.book.insert(Book(rawID: "Verge", authorID: .init("muukii")))
         }
@@ -240,7 +240,7 @@ class ORMGetterTests: XCTestCase {
     
     XCTContext.runActivity(named: "Add other author") { _ in
       
-      storage.commit { state in
+      _ = storage.commit { state in
         state.db.performBatchUpdates { (context) in
           context.author.insert(.init(rawID: "John", name: "John"))
         }

--- a/Tests/VergeRxTests/FunctionBuilderTests.swift
+++ b/Tests/VergeRxTests/FunctionBuilderTests.swift
@@ -15,20 +15,20 @@ enum FunctionBuilderTests {
   
   static func test() {
     
-    SubscriptionGroup {
+    _ = SubscriptionGroup {
       
       Single.just(1).subscribe()
       
     }
     
-    SubscriptionGroup {
+    _ = SubscriptionGroup {
       
       Single.just(1).subscribe()
       Single.just(1).subscribe()
             
     }
     
-    SubscriptionGroup {
+    _ = SubscriptionGroup {
       [
       Single.just(1).subscribe(),
       Single.just(1).subscribe()

--- a/Tests/VergeRxTests/MigrationFromClassicTests.swift
+++ b/Tests/VergeRxTests/MigrationFromClassicTests.swift
@@ -213,7 +213,7 @@ enum MigrationExample {
       
       let viewModel = ViewModel()
       
-      viewModel.rx.changesObservable
+      _ = viewModel.rx.changesObservable
       
     }
     

--- a/Tests/VergeRxTests/MultithreadingTests.swift
+++ b/Tests/VergeRxTests/MultithreadingTests.swift
@@ -34,7 +34,7 @@ class MultithreadingTests: XCTestCase {
       self.store.rx.nonNullEntityGetter(from: $0)
     }
     .forEach { getter in
-      getter
+      _ = getter
         .do(onNext: { e in
 //          print(Thread.current, e)
         })

--- a/Tests/VergeRxTests/ORMGetterTests.swift
+++ b/Tests/VergeRxTests/ORMGetterTests.swift
@@ -176,7 +176,7 @@ class ORMGetterTests: XCTestCase {
     
     XCTContext.runActivity(named: "updateName") { _ in
       
-      storage.commit { state in
+      _ = storage.commit { state in
         state.db.performBatchUpdates { (context) in
           context.author.updateIfExists(id: .init("muukii")) { (author) in
             author.name = "Hiroshi"
@@ -192,7 +192,7 @@ class ORMGetterTests: XCTestCase {
     
     XCTContext.runActivity(named: "updateName, but not changed") { _ in
       
-      storage.commit { state in
+      _ = storage.commit { state in
         state.db.performBatchUpdates { (context) in
           context.author.updateIfExists(id: .init("muukii")) { (author) in
             author.name = "Hiroshi"
@@ -220,7 +220,7 @@ class ORMGetterTests: XCTestCase {
     
     XCTContext.runActivity(named: "Adding book, getter would not emit changes") { _ -> Void in
       
-      storage.commit { state in
+      _ = storage.commit { state in
         state.db.performBatchUpdates { (context) in
           context.book.insert(Book(rawID: "Verge", authorID: .init("muukii")))
         }

--- a/Tests/VergeRxTests/ReproduceDeadlockTests.swift
+++ b/Tests/VergeRxTests/ReproduceDeadlockTests.swift
@@ -32,7 +32,7 @@ class ReproduceDeadlockTests: XCTestCase {
     
     wait(for: [], timeout: 1)
     
-    store.rx.stateObservable.bind { state in
+    _ = store.rx.stateObservable.bind { state in
       if state.count == 1 {
         let group = DispatchGroup()
         group.enter()

--- a/Tests/VergeRxTests/ReproduceDeadlockTests.swift
+++ b/Tests/VergeRxTests/ReproduceDeadlockTests.swift
@@ -1,0 +1,50 @@
+//
+//  ReproduceDeadlockTests.swift
+//  VergeStoreTests
+//
+//  Created by muukii on 2020/04/20.
+//  Copyright © 2020 muukii. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+import VergeStore
+import VergeRx
+
+class ReproduceDeadlockTests: XCTestCase {
+  
+  struct StoreWrapper: StoreWrapperType {
+        
+    struct State: StateType {
+      var count = 0
+    }
+    
+    enum Activity {}
+    
+    let store = DefaultStore.init(initialState: .init(), logger: nil)
+    
+  }
+  
+  func testReproduceDeadlock() {
+    
+    let store = StoreWrapper()
+    
+    store.rx.stateObservable.bind { state in
+      if state.count == 1 {
+        let group = DispatchGroup()
+        group.enter()
+        DispatchQueue.global().async {
+          store.commit { $0.count += 1 }
+          group.leave()
+        }
+        group.wait()
+      }
+    }
+        
+    store.commit {
+      $0.count += 1
+    }
+        
+  }
+}

--- a/Tests/VergeRxTests/ReproduceDeadlockTests.swift
+++ b/Tests/VergeRxTests/ReproduceDeadlockTests.swift
@@ -30,6 +30,8 @@ class ReproduceDeadlockTests: XCTestCase {
     
     let store = StoreWrapper()
     
+    wait(for: [], timeout: 1)
+    
     store.rx.stateObservable.bind { state in
       if state.count == 1 {
         let group = DispatchGroup()
@@ -45,6 +47,7 @@ class ReproduceDeadlockTests: XCTestCase {
     store.commit {
       $0.count += 1
     }
+    
         
   }
 }

--- a/Tests/VergeRxTests/State.swift
+++ b/Tests/VergeRxTests/State.swift
@@ -58,7 +58,7 @@ struct RootState: StateType, DatabaseEmbedding {
     var middlewares: [AnyMiddleware<RootState.Database>] {
       [
         AnyMiddleware<RootState.Database>(performAfterUpdates: { (context) in
-          let ids = context.author.all().map { $0.id }
+          let ids = context.author.all().map { $0.entityID }
           context.indexes.bookMiddleware.append(contentsOf: ids)
         })
       ]

--- a/Tests/VergeStoreTests/VergeStoreTests.swift
+++ b/Tests/VergeStoreTests/VergeStoreTests.swift
@@ -212,13 +212,7 @@ final class VergeStoreTests: XCTestCase {
   override func tearDown() {
     // Put teardown code here. This method is called after the invocation of each test method in the class.
   }
-  
-  func testScope() {
     
-    let store = Store()
-    
-  }
-  
   @available(iOS 13.0, *)
   func testStateSubscription() {
     

--- a/Verge.xcodeproj/project.pbxproj
+++ b/Verge.xcodeproj/project.pbxproj
@@ -1520,7 +1520,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1130;
-				LastUpgradeCheck = 1130;
+				LastUpgradeCheck = 1140;
 				ORGANIZATIONNAME = muukii;
 				TargetAttributes = {
 					4B17438E23C766D70074C457 = {
@@ -2244,8 +2244,9 @@
 		4B17439823C766D80074C457 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
@@ -2280,8 +2281,9 @@
 		4B17439923C766D80074C457 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
@@ -2358,6 +2360,7 @@
 		4B475BBB239AB954008A03E1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -2393,6 +2396,7 @@
 		4B475BBC239AB954008A03E1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -2566,6 +2570,7 @@
 		4B67672E23D8973800D0C076 /* Benchmark */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -2602,8 +2607,9 @@
 		4B67672F23D8973800D0C076 /* Benchmark */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO;
@@ -2676,6 +2682,7 @@
 		4B67673123D8973800D0C076 /* Benchmark */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -3465,6 +3472,7 @@
 		4BFA22A523A63B56008D7BCB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -3501,6 +3509,7 @@
 		4BFA22A623A63B56008D7BCB /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;

--- a/Verge.xcodeproj/project.pbxproj.orig
+++ b/Verge.xcodeproj/project.pbxproj.orig
@@ -46,8 +46,7 @@
 		4B475BC0239AB983008A03E1 /* DatabaseBatchUpdatesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B475BBE239AB97F008A03E1 /* DatabaseBatchUpdatesContext.swift */; };
 		4B475BC8239ADE1C008A03E1 /* VergeORMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B475BC7239ADE1C008A03E1 /* VergeORMTests.swift */; };
 		4B475BD0239ADEB4008A03E1 /* VergeORM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B475BB2239AB954008A03E1 /* VergeORM.framework */; };
-		4B4AB16C244DEEE3005E7283 /* ReproduceDeadlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4AB16A244DECC8005E7283 /* ReproduceDeadlockTests.swift */; };
-		4B4AB16E244DF35E005E7283 /* SynchronizationTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4AB16D244DF35E005E7283 /* SynchronizationTracker.swift */; };
+		4B4AB16B244DECC8005E7283 /* ReproduceDeadlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4AB16A244DECC8005E7283 /* ReproduceDeadlockTests.swift */; };
 		4B54E27B1FE36A11001736D2 /* Storage+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B54E27A1FE36A11001736D2 /* Storage+Rx.swift */; };
 		4B57FD1623A29CAA00E41D06 /* EntityTablesStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B57FD1523A29CAA00E41D06 /* EntityTablesStorage.swift */; };
 		4B57FD1A23A29DAD00E41D06 /* EntityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B57FD1923A29DAD00E41D06 /* EntityType.swift */; };
@@ -480,7 +479,6 @@
 		4B475BC9239ADE1C008A03E1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4B495D092332B5170098F7B4 /* NetworkImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkImageView.swift; sourceTree = "<group>"; };
 		4B4AB16A244DECC8005E7283 /* ReproduceDeadlockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReproduceDeadlockTests.swift; sourceTree = "<group>"; };
-		4B4AB16D244DF35E005E7283 /* SynchronizationTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizationTracker.swift; sourceTree = "<group>"; };
 		4B542434242DCE0700ECC0C9 /* GetterBuilderMethodChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetterBuilderMethodChain.swift; sourceTree = "<group>"; };
 		4B54516F23CCC7E700770E61 /* GetterComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetterComponents.swift; sourceTree = "<group>"; };
 		4B54E27A1FE36A11001736D2 /* Storage+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Storage+Rx.swift"; sourceTree = "<group>"; };
@@ -798,7 +796,6 @@
 		4B1743A823C767670074C457 /* VergeRxTests */ = {
 			isa = PBXGroup;
 			children = (
-				4B4AB16A244DECC8005E7283 /* ReproduceDeadlockTests.swift */,
 				4B4011BC23C779D400C582BC /* State.swift */,
 				4BB97D2423AFD0A9004EECDB /* ORMGetterTests.swift */,
 				4B232761239E71530043D3F9 /* MemoizeGetterTests.swift */,
@@ -880,6 +877,11 @@
 				4B71CEED23B14394004520CE /* ActivityTests.swift */,
 				4BCE8C2123CF736300FD30D9 /* MostSimpleSampleTests.swift */,
 				4B1F19C3243A88A000CED46B /* ComputedTests.swift */,
+<<<<<<< Updated upstream
+=======
+				4BAFD7E924488B4800C7D38D /* WrapperTests.swift */,
+				4B4AB16A244DECC8005E7283 /* ReproduceDeadlockTests.swift */,
+>>>>>>> Stashed changes
 			);
 			path = VergeStoreTests;
 			sourceTree = "<group>";
@@ -1178,7 +1180,6 @@
 				4BF470CC23CC36E8001A1D5D /* FragmentState.swift */,
 				4BF470D123CC3A43001A1D5D /* UpdatedMarker.swift */,
 				4BD79C0324477F430073A48B /* VergeConcurrency.swift */,
-				4B4AB16D244DF35E005E7283 /* SynchronizationTracker.swift */,
 			);
 			path = VergeCore;
 			sourceTree = "<group>";
@@ -1867,7 +1868,6 @@
 				4B8035FB244CB96B0028BD32 /* MigrationFromClassicTests.swift in Sources */,
 				4BF3C2EE24209620006B1726 /* MultithreadingTests.swift in Sources */,
 				4B4011BB23C779BE00C582BC /* ORMGetterTests.swift in Sources */,
-				4B4AB16C244DEEE3005E7283 /* ReproduceDeadlockTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1923,6 +1923,7 @@
 			files = (
 				4BCE8C2223CF736300FD30D9 /* MostSimpleSampleTests.swift in Sources */,
 				4B6B77AC243FA6B300E0C0EA /* GetterSyntaxTests.swift in Sources */,
+				4B4AB16B244DECC8005E7283 /* ReproduceDeadlockTests.swift in Sources */,
 				4B6B77AD243FA6B300E0C0EA /* GetterTests.swift in Sources */,
 				4B68394723705ACE002FFC5A /* VergeStoreTests.swift in Sources */,
 				4B86D828244AFE1D008D3040 /* MemoizeGetterTests.swift in Sources */,
@@ -2048,7 +2049,6 @@
 				4B73F08924041811006910E6 /* Log.swift in Sources */,
 				4BA3E1A523C359F40095629B /* Signpost.swift in Sources */,
 				4BFA22B323A63C38008D7BCB /* EventEmitter.swift in Sources */,
-				4B4AB16E244DF35E005E7283 /* SynchronizationTracker.swift in Sources */,
 				4BD79C0424477F430073A48B /* VergeConcurrency.swift in Sources */,
 				4BFA22BC23A642B3008D7BCB /* Storage.swift in Sources */,
 			);

--- a/Verge.xcodeproj/xcshareddata/xcschemes/VergeClassic.xcscheme
+++ b/Verge.xcodeproj/xcshareddata/xcschemes/VergeClassic.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Verge.xcodeproj/xcshareddata/xcschemes/VergeORM.xcscheme
+++ b/Verge.xcodeproj/xcshareddata/xcschemes/VergeORM.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Verge.xcodeproj/xcshareddata/xcschemes/VergeORMTests.xcscheme
+++ b/Verge.xcodeproj/xcshareddata/xcschemes/VergeORMTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Verge.xcodeproj/xcshareddata/xcschemes/VergeRx.xcscheme
+++ b/Verge.xcodeproj/xcshareddata/xcschemes/VergeRx.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Verge.xcodeproj/xcshareddata/xcschemes/VergeStore.xcscheme
+++ b/Verge.xcodeproj/xcshareddata/xcschemes/VergeStore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Verge.xcodeproj/xcshareddata/xcschemes/VergeStoreAdvancedDemo.xcscheme
+++ b/Verge.xcodeproj/xcshareddata/xcschemes/VergeStoreAdvancedDemo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Verge.xcodeproj/xcshareddata/xcschemes/VergeStoreDemoSwiftUI.xcscheme
+++ b/Verge.xcodeproj/xcshareddata/xcschemes/VergeStoreDemoSwiftUI.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Verge.xcodeproj/xcshareddata/xcschemes/VergeStoreTests.xcscheme
+++ b/Verge.xcodeproj/xcshareddata/xcschemes/VergeStoreTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Verge.xcodeproj/xcshareddata/xcschemes/VergeViewModel.xcscheme
+++ b/Verge.xcodeproj/xcshareddata/xcschemes/VergeViewModel.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Verge.xcodeproj/xcshareddata/xcschemes/VergeViewModelTests.xcscheme
+++ b/Verge.xcodeproj/xcshareddata/xcschemes/VergeViewModelTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Verge.xcworkspace/xcshareddata/xcschemes/All.xcscheme
+++ b/Verge.xcworkspace/xcshareddata/xcschemes/All.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.1">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
![Untitled](https://user-images.githubusercontent.com/1888355/79769327-f0518a80-8366-11ea-920a-b98658461bce.png)

Sometimes,  a crash will be caused by a commit.
the detail of crashes is not cleary, because it's from memory issue.

BehaviorSubject can't receive simultaneously from multiple threads.
Therefore, I put the lock while publishing events.

However, this fixing may cause dead-lock.
That if we dispatch commit to another thread synchronously in subscribing closure.
