### PR TITLE
Remove composing

### DIFF
--- a/Sources/VergeRx/Store+Rx.swift
+++ b/Sources/VergeRx/Store+Rx.swift
@@ -111,9 +111,7 @@ extension ObservableType where Element : ChangesType, Element.Value : Equatable 
 }
 
 extension ObservableType where Element : ChangesType {
-  
-  public typealias Composing = Changes<Element.Value>.Composing
-  
+      
   /// Returns an observable sequence that contains only changed elements according to the `comparer`.
   ///
   /// Using Changes under
@@ -122,7 +120,7 @@ extension ObservableType where Element : ChangesType {
   ///   - selector:
   ///   - compare:
   /// - Returns: Returns an observable sequence that contains only changed elements according to the `comparer`.
-  public func changed<S>(_ selector: @escaping (Composing) -> S, _ compare: @escaping (S, S) -> Bool) -> Observable<S> {
+  public func changed<S>(_ selector: @escaping (Changes<Element.Value>) -> S, _ compare: @escaping (S, S) -> Bool) -> Observable<S> {
     
     return flatMap { changes -> Observable<S> in
       let _r = changes.asChanges().ifChanged(selector, compare) { value in
@@ -140,7 +138,7 @@ extension ObservableType where Element : ChangesType {
   ///   - selector:
   ///   - comparer:
   /// - Returns: Returns an observable sequence that contains only changed elements according to the `comparer`.
-  public func changed<S : Equatable>(_ selector: @escaping (Composing) -> S) -> Observable<S> {
+  public func changed<S : Equatable>(_ selector: @escaping (Changes<Element.Value>) -> S) -> Observable<S> {
     return changed(selector, ==)
   }
     
@@ -152,7 +150,7 @@ extension ObservableType where Element : ChangesType {
   ///   - selector:
   ///   - compare:
   /// - Returns: Returns an observable sequence that contains only changed elements according to the `comparer`.
-  public func changedDriver<S>(_ selector: @escaping (Composing) -> S, _ compare: @escaping (S, S) -> Bool) -> Driver<S> {
+  public func changedDriver<S>(_ selector: @escaping (Changes<Element.Value>) -> S, _ compare: @escaping (S, S) -> Bool) -> Driver<S> {
     changed(selector, compare)
         .asDriver(onErrorRecover: { _ in .empty() })
   }
@@ -165,7 +163,7 @@ extension ObservableType where Element : ChangesType {
   ///   - selector:
   ///   - comparer:
   /// - Returns: Returns an observable sequence that contains only changed elements according to the `comparer`.
-  public func changedDriver<S : Equatable>(_ selector: @escaping (Composing) -> S) -> Driver<S> {
+  public func changedDriver<S : Equatable>(_ selector: @escaping (Changes<Element.Value>) -> S) -> Driver<S> {
     return changedDriver(selector, ==)
   }
   

--- a/Sources/VergeStore/Store/Derived.swift
+++ b/Sources/VergeStore/Store/Derived.swift
@@ -149,7 +149,7 @@ public class Derived<Value>: DerivedType {
   }
   
   fileprivate func _makeChain<NewState>(
-    _ map: MemoizeMap<Changes<Value>.Composing, NewState>,
+    _ map: MemoizeMap<Changes<Value>, NewState>,
     queue: DispatchQueue? = nil
   ) -> Derived<NewState> {
     
@@ -157,9 +157,9 @@ public class Derived<Value>: DerivedType {
     
     let d = Derived<NewState>(
       get: .init(makeInitial: {
-        map.makeInitial($0.makeComposing())
+        map.makeInitial($0)
       }, update: {
-        switch map.makeResult($0.makeComposing()) {
+        switch map.makeResult($0) {
         case .noChanages: return .noChanages
         case .updated(let s): return .updated(s)
         }
@@ -187,7 +187,7 @@ public class Derived<Value>: DerivedType {
   ///   - dropsOutput: a condition to drop a duplicated(no-changes) object. (Default: no drops)
   /// - Returns: Derived object that cached depends on the specified parameters
   public func chain<NewState>(
-    _ map: MemoizeMap<Changes<Value>.Composing, NewState>,
+    _ map: MemoizeMap<Changes<Value>, NewState>,
     dropsOutput: ((Changes<NewState>) -> Bool)? = nil,
     queue: DispatchQueue? = nil
     ) -> Derived<NewState> {
@@ -228,7 +228,7 @@ public class Derived<Value>: DerivedType {
   ///   - map:
   /// - Returns: Derived object that cached depends on the specified parameters
   public func chain<NewState: Equatable>(
-    _ map: MemoizeMap<Changes<Value>.Composing, NewState>,
+    _ map: MemoizeMap<Changes<Value>, NewState>,
     queue: DispatchQueue? = nil
   ) -> Derived<NewState> {
     
@@ -508,7 +508,7 @@ extension StoreType {
     }
     
     if let dropsOutput = dropsOutput {
-      
+            
       let chained = derived._makeChain(.map(\.root), queue: queue)
       chained.setDropsOutput(dropsOutput)
             


### PR DESCRIPTION
Composing type sometimes makes type-system confusing.
there is no strong reason to keep it, removes it.