### PR TITLE
Add variant ifChanged method

### DIFF
--- a/Sources/VergeStore/Changes.swift
+++ b/Sources/VergeStore/Changes.swift
@@ -223,6 +223,25 @@ public final class Changes<Value>: ChangesType {
   public func ifChanged<T: Equatable, Result>(_ keyPath: ChangesKeyPath<T>, _ perform: (T) throws -> Result) rethrows -> Result? {
     try ifChanged(keyPath, ==, perform)
   }
+
+  @inline(__always)
+  public func ifChanged<T0: Equatable, T1: Equatable, Result>(
+    _ keyPath0: ChangesKeyPath<T0>,
+    _ keyPath1: ChangesKeyPath<T1>,
+    _ perform: ((T0, T1)) throws -> Result
+  ) rethrows -> Result? {
+    try ifChanged({ ($0[keyPath: keyPath0], $0[keyPath: keyPath1]) }, ==, perform)
+  }
+
+  @inline(__always)
+  public func ifChanged<T0: Equatable, T1: Equatable, T2: Equatable, Result>(
+    _ keyPath0: ChangesKeyPath<T0>,
+    _ keyPath1: ChangesKeyPath<T1>,
+    _ keyPath2: ChangesKeyPath<T2>,
+    _ perform: ((T0, T1, T2)) throws -> Result
+  ) rethrows -> Result? {
+    try ifChanged({ ($0[keyPath: keyPath0], $0[keyPath: keyPath1], $0[keyPath: keyPath2]) }, ==, perform)
+  }
   
   /// Do a closure if value specified by keyPath contains changes.
   public func ifChanged<T, Result>(_ selector: ChangesKeyPath<T>, _ comparer: (T, T) -> Bool, _ perform: (T) throws -> Result) rethrows -> Result? {

--- a/Tests/DemoState.swift
+++ b/Tests/DemoState.swift
@@ -10,11 +10,15 @@ import Foundation
 
 import VergeStore
 
+struct NonEquatable {}
+
 struct DemoState: ExtendedStateType {
   
   var name: String = ""
   var count: Int = 0
   var items: [Int] = []
+
+  var nonEquatable: NonEquatable = .init()
   
   struct Extended: ExtendedType {
     

--- a/Tests/VergeStoreTests/SyntaxTests.swift
+++ b/Tests/VergeStoreTests/SyntaxTests.swift
@@ -1,0 +1,37 @@
+//
+//  SyntaxTests.swift
+//  VergeStoreTests
+//
+//  Created by muukii on 2020/05/24.
+//  Copyright © 2020 muukii. All rights reserved.
+//
+
+import Foundation
+
+import VergeStore
+
+enum SyntaxTests {
+
+  static func code() {
+
+    let changes: Changes<DemoState> = .init(old: nil, new: .init())
+
+    changes.ifChanged(\.name) { name in
+
+    }
+
+    changes.ifChanged(\.nonEquatable, { _, _ in false }) { name in
+
+    }
+
+
+    changes.ifChanged({ $0.name }) { name in
+
+    }
+
+    changes.ifChanged(\.name, \.count) { name, count in
+
+    }
+
+  }
+}

--- a/Verge.xcodeproj/project.pbxproj
+++ b/Verge.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		4B8F5ABB24616416005F68B6 /* VergeConcurrency+AtomicReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B8F5ABA24616416005F68B6 /* VergeConcurrency+AtomicReference.swift */; };
 		4B91B3782440B9C4005082D7 /* VergeStore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B786320233912AB009B9C1B /* VergeStore.framework */; };
 		4B91B3792440B9C4005082D7 /* VergeStore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4B786320233912AB009B9C1B /* VergeStore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		4B93C875247A523500372BC4 /* SyntaxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B93C874247A523500372BC4 /* SyntaxTests.swift */; };
 		4B94913C239C25C600370067 /* VergeStore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B786320233912AB009B9C1B /* VergeStore.framework */; };
 		4B94913D239C25C600370067 /* VergeStore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4B786320233912AB009B9C1B /* VergeStore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4B949141239C25CA00370067 /* VergeORM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B475BB2239AB954008A03E1 /* VergeORM.framework */; };
@@ -544,6 +545,7 @@
 		4B8EB4F823C034A900035B2A /* Comparer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comparer.swift; sourceTree = "<group>"; };
 		4B8F5AB6246160AB005F68B6 /* VergeConcurrency+AtomicInt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VergeConcurrency+AtomicInt.swift"; sourceTree = "<group>"; };
 		4B8F5ABA24616416005F68B6 /* VergeConcurrency+AtomicReference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VergeConcurrency+AtomicReference.swift"; sourceTree = "<group>"; };
+		4B93C874247A523500372BC4 /* SyntaxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxTests.swift; sourceTree = "<group>"; };
 		4B93EC7323307637002BB30B /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		4B949128239C257500370067 /* VergeStoreDemoSwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VergeStoreDemoSwiftUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B949146239C264D00370067 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -924,6 +926,7 @@
 				4B35F5742376A692005E6C01 /* SynchronizeDisplayValueTests.swift */,
 				4B71CEED23B14394004520CE /* ActivityTests.swift */,
 				4B1F19C3243A88A000CED46B /* ComputedTests.swift */,
+				4B93C874247A523500372BC4 /* SyntaxTests.swift */,
 			);
 			path = VergeStoreTests;
 			sourceTree = "<group>";
@@ -1991,6 +1994,7 @@
 			files = (
 				4B95BE5A244F10F200124F6B /* DemoState.swift in Sources */,
 				4B68394723705ACE002FFC5A /* VergeStoreTests.swift in Sources */,
+				4B93C875247A523500372BC4 /* SyntaxTests.swift in Sources */,
 				4B6B77AE243FA6B300E0C0EA /* FilterTests.swift in Sources */,
 				4B86D826244A2A1D008D3040 /* Sample.swift in Sources */,
 				4B1F19C4243A88A000CED46B /* ComputedTests.swift in Sources */,


### PR DESCRIPTION
```swift
  @inline(__always)
  public func ifChanged<T0: Equatable, T1: Equatable, Result>(
    _ keyPath0: ChangesKeyPath<T0>,
    _ keyPath1: ChangesKeyPath<T1>,
    _ perform: ((T0, T1)) throws -> Result
  ) rethrows -> Result? {
    try ifChanged({ ($0[keyPath: keyPath0], $0[keyPath: keyPath1]) }, ==, perform)
  }

  @inline(__always)
  public func ifChanged<T0: Equatable, T1: Equatable, T2: Equatable, Result>(
    _ keyPath0: ChangesKeyPath<T0>,
    _ keyPath1: ChangesKeyPath<T1>,
    _ keyPath2: ChangesKeyPath<T2>,
    _ perform: ((T0, T1, T2)) throws -> Result
  ) rethrows -> Result? {
    try ifChanged({ ($0[keyPath: keyPath0], $0[keyPath: keyPath1], $0[keyPath: keyPath2]) }, ==, perform)
  }
```